### PR TITLE
Implement Active Deployments; smarter redeploys

### DIFF
--- a/app/DeploymentSteps.php
+++ b/app/DeploymentSteps.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App;
+
+use App\Jobs\ConfigureQueues;
+use App\Jobs\CreateCloudRunService;
+use App\Jobs\CreateImageForDeployment;
+use App\Jobs\EnsureAppIsPublic;
+use App\Jobs\FinalizeDeployment;
+use App\Jobs\StartDeployment;
+use App\Jobs\StartScheduler;
+use App\Jobs\UpdateCloudRunService;
+use App\Jobs\UpdateCloudRunServiceWithUrls;
+use App\Jobs\WaitForCloudRunServiceToDeploy;
+use App\Jobs\WaitForImageToBeBuilt;
+
+class DeploymentSteps
+{
+    protected $deployment;
+
+    protected $isInitialDeployment = false;
+
+    protected $isRedeploy = false;
+
+    /**
+     * @var \Illuminate\Support\Collection
+     */
+    protected $steps;
+
+    public function __construct(Deployment $deployment)
+    {
+        $this->deployment = $deployment;
+        $this->steps = collect();
+    }
+
+    public static function for(Deployment $deployment)
+    {
+        return new static($deployment);
+    }
+
+    public function initialDeployment()
+    {
+        $this->isInitialDeployment = true;
+
+        return $this;
+    }
+
+    public function redeploy()
+    {
+        $this->isRedeploy = true;
+
+        return $this;
+    }
+
+    protected function projectType(): string
+    {
+        return $this->deployment->environment->project->type;
+    }
+
+    protected function shouldStartScheduler()
+    {
+        return $this->isInitialDeployment && $this->usesScheduler();
+    }
+
+    protected function usesScheduler(): bool
+    {
+        return in_array($this->projectType(), ['laravel']);
+    }
+
+    public function addStep(...$values)
+    {
+        foreach ($values as $step) {
+            $this->steps->push($step);
+        }
+    }
+
+    public function get(): array
+    {
+        $this->addStep(StartDeployment::class);
+
+        if (!$this->isRedeploy) {
+            $this->addStep(CreateImageForDeployment::class);
+        }
+
+        $this->addStep(ConfigureQueues::class);
+
+        if (!$this->isRedeploy) {
+            $this->addStep(WaitForImageToBeBuilt::class);
+        }
+
+        $this->addStep($this->isInitialDeployment ? CreateCloudRunService::class : UpdateCloudRunService::class);
+
+        $this->addStep(WaitForCloudRunServiceToDeploy::class);
+
+        if ($this->isInitialDeployment) {
+            $this->addStep(
+                UpdateCloudRunServiceWithUrls::class,
+                // Deploy the service another time, since we now have URL env vars set
+                WaitForCloudRunServiceToDeploy::class,
+                EnsureAppIsPublic::class
+            );
+        }
+
+        if ($this->shouldStartScheduler()) {
+            $this->addStep(StartScheduler::class);
+        }
+
+        $this->addStep(FinalizeDeployment::class);
+
+        return $this->steps
+            ->map(fn ($step) => new $step($this->deployment))
+            ->toArray();
+    }
+}

--- a/app/Environment.php
+++ b/app/Environment.php
@@ -59,8 +59,7 @@ class Environment extends Model
      */
     public function activeDeployment()
     {
-        // TODO: Update logic to actually set an active_deployment_id when a deployment is active
-        return $this->deployments()->first();
+        return $this->belongsTo('App\Deployment', 'active_deployment_id');
     }
 
     /**
@@ -279,7 +278,7 @@ class Environment extends Model
      */
     public function setUrl($url)
     {
-        if (! empty($this->url)) return;
+        if (!empty($this->url)) return;
 
         $this->url = $url;
         $this->save();
@@ -295,7 +294,7 @@ class Environment extends Model
      */
     public function setWorkerUrl($url)
     {
-        if (! empty($this->worker_url)) return;
+        if (!empty($this->worker_url)) return;
 
         $this->worker_url = $url;
         $this->save();

--- a/app/Environment.php
+++ b/app/Environment.php
@@ -3,17 +3,6 @@
 namespace App;
 
 use App\GoogleCloud\SchedulerJobConfig;
-use App\Jobs\ConfigureQueues;
-use App\Jobs\CreateCloudRunService;
-use App\Jobs\CreateImageForDeployment;
-use App\Jobs\EnsureAppIsPublic;
-use App\Jobs\FinalizeDeployment;
-use App\Jobs\StartDeployment;
-use App\Jobs\StartScheduler;
-use App\Jobs\UpdateCloudRunService;
-use App\Jobs\UpdateCloudRunServiceWithUrls;
-use App\Jobs\WaitForCloudRunServiceToDeploy;
-use App\Jobs\WaitForImageToBeBuilt;
 use App\Services\GoogleApi;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Encryption\Encrypter;

--- a/app/Environment.php
+++ b/app/Environment.php
@@ -239,7 +239,6 @@ class Environment extends Model
             new WaitForImageToBeBuilt($deployment),
             new UpdateCloudRunService($deployment),
             new WaitForCloudRunServiceToDeploy($deployment),
-            new EnsureAppIsPublic($deployment),
             new FinalizeDeployment($deployment),
         ])->dispatch();
 
@@ -266,7 +265,6 @@ class Environment extends Model
             new ConfigureQueues($deployment),
             new UpdateCloudRunService($deployment),
             new WaitForCloudRunServiceToDeploy($deployment),
-            new EnsureAppIsPublic($deployment),
             new FinalizeDeployment($deployment),
         ])->dispatch();
 

--- a/app/Jobs/DeploymentStepJob.php
+++ b/app/Jobs/DeploymentStepJob.php
@@ -33,7 +33,7 @@ abstract class DeploymentStepJob implements ShouldQueue
     /**
      * The environment associated with the job.
      *
-     * @var \App\Deployment
+     * @var \App\Environment
      */
     public Environment $environment;
 
@@ -44,7 +44,8 @@ abstract class DeploymentStepJob implements ShouldQueue
      */
     public $step;
 
-    public function __construct(Deployment $deployment) {
+    public function __construct(Deployment $deployment)
+    {
         $this->deployment = $deployment;
         $this->environment = $deployment->environment;
 

--- a/app/Jobs/FinalizeDeployment.php
+++ b/app/Jobs/FinalizeDeployment.php
@@ -8,6 +8,9 @@ class FinalizeDeployment extends DeploymentStepJob
     {
         $this->deployment->markAsSuccessful();
 
+        $this->environment->activeDeployment()->associate($this->deployment);
+        $this->environment->save();
+
         return true;
     }
 }

--- a/app/Jobs/StartScheduler.php
+++ b/app/Jobs/StartScheduler.php
@@ -7,5 +7,7 @@ class StartScheduler extends DeploymentStepJob
     public function execute()
     {
         $this->environment->startScheduler();
+
+        return true;
     }
 }

--- a/database/migrations/2020_01_23_172455_create_environments_table.php
+++ b/database/migrations/2020_01_23_172455_create_environments_table.php
@@ -17,7 +17,8 @@ class CreateEnvironmentsTable extends Migration
             $table->bigIncrements('id');
             $table->unsignedBigInteger('project_id')->index();
             $table->unsignedBigInteger('database_id')->nullable();
-            $table->string('name');
+            $table->string('name')->index();
+            $table->unsignedBigInteger('active_deployment_id')->nullable()->index();
             $table->string('branch')->default('master')->index();
             $table->string('url')->nullable();
             $table->string('worker_url')->nullable();

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -15,7 +15,9 @@
                         <x-white-button :href="$project->productionUrl()">Visit</x-white-button>
                     </x-slot>
                     <p>{{ \App\Project::TYPES[$project->type] }} / {{ $project->region }} / {{ $project->googleProject->name }}</p>
-                    <p>Last deployed {{ $project->environments()->first()->activeDeployment()->created_at->diffForHumans() }}</p>
+                    @if ($project->production()->activeDeployment()->exists())
+                        <p>Last deployed {{ $project->environments()->first()->activeDeployment()->created_at->diffForHumans() }}</p>
+                    @endif
                 </x-card>
             @endforeach
         @else

--- a/tests/Feature/DeploymentTest.php
+++ b/tests/Feature/DeploymentTest.php
@@ -69,6 +69,26 @@ class DeploymentTest extends TestCase
 
         $this->assertEquals('successful', $deployment->status);
         $this->assertTrue($environment->activeDeployment->is($deployment));
+
+        $steps = [
+            'StartDeployment',
+            'CreateImageForDeployment',
+            'ConfigureQueues',
+            'WaitForImageToBeBuilt',
+            'CreateCloudRunService',
+            'WaitForCloudRunServiceToDeploy',
+            'UpdateCloudRunServiceWithUrls',
+            'WaitForCloudRunServiceToDeploy',
+            'EnsureAppIsPublic',
+            'StartScheduler',
+            'FinalizeDeployment',
+        ];
+
+        foreach ($steps as $step) {
+            $deploymentStep = $deployment->steps()->where('name', $step)->first();
+            $this->assertTrue($deploymentStep->exists());
+            $this->assertTrue($deploymentStep->hasFinished());
+        }
     }
 
     public function test_deployment_is_marked_as_failed_if_a_job_fails()

--- a/tests/Feature/DeploymentTest.php
+++ b/tests/Feature/DeploymentTest.php
@@ -269,5 +269,6 @@ class DeploymentTest extends TestCase
         ];
 
         $this->assertCount(count($steps), $deployment->steps);
+        $this->assertEquals($steps, $deployment->steps()->pluck('name')->toArray());
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,15 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    /**
+     * Load a stub
+     *
+     * @param string $name
+     * @return array
+     */
+    protected function loadStub($name)
+    {
+        return json_decode(file_get_contents(__DIR__ . "/stubs/{$name}.json"), true);
+    }
 }

--- a/tests/Unit/CloudRunServiceTest.php
+++ b/tests/Unit/CloudRunServiceTest.php
@@ -50,15 +50,4 @@ class CloudRunServiceTest extends TestCase
             $service->getError()
         );
     }
-
-    /**
-     * Load a stub
-     *
-     * @param string $name
-     * @return array
-     */
-    protected function loadStub($name)
-    {
-        return json_decode(file_get_contents(__DIR__ . "/../stubs/{$name}.json"), true);
-    }
 }


### PR DESCRIPTION
Fixes #24 
Fixes #25 

Adds a new `active_deployment_id` column to `Deployments` as well as logic to mark a given deployment as active when it is finalized.

If no active deployment yet exists for an environment, its initial deployment will be re-run whenever the next redeploy is attempted.

Refactors logic to a new `DeploymentSteps` helper class.