### PR TITLE
Build projects more securely

### DIFF
--- a/app/DeploymentSteps.php
+++ b/app/DeploymentSteps.php
@@ -7,6 +7,7 @@ use App\Jobs\CreateCloudRunService;
 use App\Jobs\CreateImageForDeployment;
 use App\Jobs\EnsureAppIsPublic;
 use App\Jobs\FinalizeDeployment;
+use App\Jobs\SetBuildSecrets;
 use App\Jobs\StartDeployment;
 use App\Jobs\StartScheduler;
 use App\Jobs\UpdateCloudRunService;
@@ -79,6 +80,7 @@ class DeploymentSteps
         $this->addStep(StartDeployment::class);
 
         if (!$this->isRedeploy) {
+            $this->addStep(SetBuildSecrets::class);
             $this->addStep(CreateImageForDeployment::class);
         }
 

--- a/app/Environment.php
+++ b/app/Environment.php
@@ -4,7 +4,6 @@ namespace App;
 
 use App\GoogleCloud\SchedulerJobConfig;
 use App\Services\GoogleApi;
-use Google\Cloud\SecretManager\V1\SecretVersion;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Facades\Bus;
@@ -357,7 +356,7 @@ class Environment extends Model
      * @param string $value
      * @return void
      */
-    public function setSecret(string $key, string $value): SecretVersion
+    public function setSecret(string $key, string $value)
     {
         return $this->client()->setSecret($key, $value);
     }

--- a/app/Environment.php
+++ b/app/Environment.php
@@ -4,6 +4,7 @@ namespace App;
 
 use App\GoogleCloud\SchedulerJobConfig;
 use App\Services\GoogleApi;
+use Google\Cloud\SecretManager\V1\SecretVersion;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Facades\Bus;
@@ -347,6 +348,32 @@ class Environment extends Model
     public function startScheduler()
     {
         return $this->client()->createSchedulerJob(new SchedulerJobConfig($this));
+    }
+
+    /**
+     * Set a secret using Google Secret Manager for this environment.
+     *
+     * @param string $key
+     * @param string $value
+     * @return void
+     */
+    public function setSecret(string $key, string $value): SecretVersion
+    {
+        return $this->client()->setSecret($key, $value);
+    }
+
+    /**
+     * The git token secret name to be used during Cloud Build.
+     *
+     * @return string
+     */
+    public function gitTokenSecretName(): string
+    {
+        return sprintf(
+            '%s-%s',
+            'rafter-git-token',
+            $this->slug()
+        );
     }
 
     /**

--- a/app/GoogleCloud/CloudBuildConfig.php
+++ b/app/GoogleCloud/CloudBuildConfig.php
@@ -12,7 +12,8 @@ class CloudBuildConfig
     protected $deployment;
     protected $environment;
 
-    public function __construct(Deployment $deployment) {
+    public function __construct(Deployment $deployment)
+    {
         $this->deployment = $deployment;
         $this->environment = $deployment->environment;
     }
@@ -50,7 +51,7 @@ class CloudBuildConfig
      */
     public function isGitBased()
     {
-        return ! $this->isManual();
+        return !$this->isManual();
     }
 
     /**
@@ -140,6 +141,19 @@ class CloudBuildConfig
                 'name' => 'gcr.io/cloud-builders/docker',
                 'entrypoint' => 'bash',
                 'args' => ['-c', "docker pull {$this->imageLocation()}:latest || exit 0"],
+            ],
+
+            // Pull down git token secret data
+            [
+                'name' => 'gcr.io/cloud-builders/gcloud',
+                'entrypoint' => 'bash',
+                'args' => ['-c', 'gcloud secrets versions access latest --secret=' . $this->deployment->environment->gitTokenSecretName() . ' > git-token.txt'],
+            ],
+
+            // DEBUG: echo out the secret
+            [
+                'name' => 'ubuntu',
+                'args' => ['cat', 'git-token.txt'],
             ],
 
             $this->isGitBased() ? $this->downloadGitRepoStep() : [],

--- a/app/GoogleCloud/CloudRunIamPolicy.php
+++ b/app/GoogleCloud/CloudRunIamPolicy.php
@@ -2,14 +2,8 @@
 
 namespace App\GoogleCloud;
 
-class CloudRunIamPolicy
+class CloudRunIamPolicy extends IamPolicy
 {
-    protected $policy;
-
-    public function __construct($policy) {
-        $this->policy = $policy;
-    }
-
     /**
      * Whether the Cloud Run policy is public.
      *
@@ -19,33 +13,11 @@ class CloudRunIamPolicy
     {
         $binding = $this->getBinding('roles/run.invoker');
 
-        if (! $binding) {
+        if (!$binding) {
             return false;
         }
 
         return collect($binding['members'])->contains('allUsers');
-    }
-
-    /**
-     * Get all bindings from the plicy.
-     *
-     * @return array
-     */
-    protected function getBindings()
-    {
-        return $this->policy['bindings'] ?? [];
-    }
-
-    /**
-     * Get a specific binding
-     *
-     * @param string $role
-     * @return array|null
-     */
-    protected function getBinding($role)
-    {
-        return collect($this->getBindings())
-            ->firstWhere('role', $role);
     }
 
     /**
@@ -55,27 +27,6 @@ class CloudRunIamPolicy
      */
     public function setPublic()
     {
-        $bindings = $this->getBindings();
-
-        $bindings[] = [
-            'role' => 'roles/run.invoker',
-            'members' => [
-                'allUsers',
-            ],
-        ];
-
-        $this->policy['bindings'] = $bindings;
-
-        return $this;
-    }
-
-    /**
-     * Get the policy
-     *
-     * @return array
-     */
-    public function getPolicy()
-    {
-        return $this->policy;
+        return $this->addMemberToRole('allUsers', 'roles/run.invoker');
     }
 }

--- a/app/GoogleCloud/IamPolicy.php
+++ b/app/GoogleCloud/IamPolicy.php
@@ -2,10 +2,9 @@
 
 namespace App\GoogleCloud;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
-class ProjectIamPolicy
+class IamPolicy
 {
     protected $policy;
 
@@ -37,7 +36,7 @@ class ProjectIamPolicy
     }
 
     /**
-     * Add a member to a given role.
+     * Add a member to a given role. Ensures no duplicate members are added.
      *
      * @param string $member The member, e.g. service account email.
      * @param string $role The role, starting with `roles/`
@@ -76,7 +75,7 @@ class ProjectIamPolicy
      *
      * @return array
      */
-    public function getPolicy()
+    public function getPolicy(): array
     {
         return $this->policy;
     }

--- a/app/GoogleCloud/ProjectIamPolicy.php
+++ b/app/GoogleCloud/ProjectIamPolicy.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\GoogleCloud;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+class ProjectIamPolicy
+{
+    protected $policy;
+
+    public function __construct($policy)
+    {
+        $this->policy = $policy;
+    }
+
+    /**
+     * Get all bindings from the plicy.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getBindings(): Collection
+    {
+        return collect($this->policy['bindings'] ?? []);
+    }
+
+    /**
+     * Get a specific binding
+     *
+     * @param string $role
+     * @return array|null
+     */
+    protected function getBinding($role)
+    {
+        return $this->getBindings()
+            ->firstWhere('role', $role);
+    }
+
+    /**
+     * Add a member to a given role.
+     *
+     * @param string $member The member, e.g. service account email.
+     * @param string $role The role, starting with `roles/`
+     * @return self
+     */
+    public function addMemberToRole($member, $role)
+    {
+        $bindings = $this->getBindings();
+        $existing = $this->getBinding($role);
+
+        if ($existing) {
+            array_push($existing['members'], $member);
+            $existing['members'] = array_unique($existing['members']);
+
+            $this->policy['bindings'] = $bindings->where('role', '!=', $role)
+                ->push($existing)
+                ->toArray();
+
+            return $this;
+        }
+
+        $bindings->push([
+            'role' => $role,
+            'members' => [
+                $member,
+            ],
+        ]);
+
+        $this->policy['bindings'] = $bindings->toArray();
+
+        return $this;
+    }
+
+    /**
+     * Get the policy
+     *
+     * @return array
+     */
+    public function getPolicy()
+    {
+        return $this->policy;
+    }
+}

--- a/app/GoogleProject.php
+++ b/app/GoogleProject.php
@@ -16,6 +16,8 @@ class GoogleProject extends Model
         // To enable APIs
         'servicemanagement.googleapis.com',
         'cloudresourcemanager.googleapis.com',
+        // IAM
+        'iam.googleapis.com',
         // Cloud Run
         'run.googleapis.com',
         // Cloud Build

--- a/app/GoogleProject.php
+++ b/app/GoogleProject.php
@@ -20,13 +20,15 @@ class GoogleProject extends Model
         'run.googleapis.com',
         // Cloud Build
         'cloudbuild.googleapis.com',
-        // for DB support
+        // MySQL DB
         'sqladmin.googleapis.com',
-        // for Postgres DB support
+        // Postgres DB
         'compute.googleapis.com',
-        // for queue support
+        // Cloud Tasks
         'cloudtasks.googleapis.com',
         'appengine.googleapis.com',
+        // Secret Manager
+        'secretmanager.googleapis.com',
     ];
 
     const REGIONS = [

--- a/app/GoogleProject.php
+++ b/app/GoogleProject.php
@@ -5,6 +5,7 @@ namespace App;
 use App\Jobs\CreateAppEngineShellApp;
 use App\Jobs\DetermineProjectNumber;
 use App\Jobs\EnableProjectApis;
+use App\Jobs\GrantCloudBuildAccessToSecrets;
 use App\Jobs\SyncDatabaseInstances;
 use App\Jobs\WaitForProjectApisToBeEnabled;
 use App\Services\GoogleApi;
@@ -80,7 +81,9 @@ class GoogleProject extends Model
     {
         EnableProjectApis::withChain([
             new WaitForProjectApisToBeEnabled($this),
+            new DetermineProjectNumber($this),
             new CreateAppEngineShellApp($this),
+            new GrantCloudBuildAccessToSecrets($this),
             new SyncDatabaseInstances($this),
         ])->dispatch($this);
     }

--- a/app/Jobs/DetermineProjectNumber.php
+++ b/app/Jobs/DetermineProjectNumber.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Jobs;
+
+use App\GoogleProject;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Throwable;
+
+class DetermineProjectNumber implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected $googleProject;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(GoogleProject $googleProject)
+    {
+        $this->googleProject = $googleProject;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        try {
+            $this->googleProject->determineProjectNumber();
+        } catch (Throwable $e) {
+            $this->fail($e);
+        }
+    }
+}

--- a/app/Jobs/EnsureAppIsPublic.php
+++ b/app/Jobs/EnsureAppIsPublic.php
@@ -18,10 +18,7 @@ class EnsureAppIsPublic implements ShouldQueue
 
         // Get the existing policies
         $policy = $environment->client()->getIamPolicyForCloudRunService($environment);
-
-        if (!$policy->isPublic()) {
-            $policy->setPublic();
-        }
+        $policy->setPublic();
 
         // Update the policy
         $environment->client()->setIamPolicyForCloudRunService($environment, $policy->getPolicy());

--- a/app/Jobs/GrantCloudBuildAccessToSecrets.php
+++ b/app/Jobs/GrantCloudBuildAccessToSecrets.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Jobs;
+
+use App\GoogleProject;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class GrantCloudBuildAccessToSecrets implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected $googleProject;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(GoogleProject $googleProject)
+    {
+        $this->googleProject = $googleProject;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        try {
+            $policy = $this->googleProject->client()->getProjectIamPolicy();
+            $member = sprintf(
+                'serviceAccount:%s@cloudbuild.gserviceaccount.com',
+                $this->googleProject->project_number
+            );
+
+            $policy->addMemberToRole($member, 'roles/secretmanager.secretAccessor');
+
+            $this->googleProject->client()->setProjectIamPolicy($policy);
+        } catch (Throwable $e) {
+            Log::error($e->getMessage());
+        }
+    }
+}

--- a/app/Jobs/SetBuildSecrets.php
+++ b/app/Jobs/SetBuildSecrets.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SetBuildSecrets implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, Trackable;
+
+    public function handle()
+    {
+        $token = $this->model->sourceProvider()->token();
+
+        $enviroment = $this->model->environment;
+        $secretName = $enviroment->gitTokenSecretName();
+
+        $this->model->environment->setSecret($secretName, $token);
+
+        return true;
+    }
+}

--- a/app/Jobs/Trackable.php
+++ b/app/Jobs/Trackable.php
@@ -38,6 +38,11 @@ trait Trackable
         return [new Tracked];
     }
 
+    public function appendToFailureOutput(): string
+    {
+        return '';
+    }
+
     /**
      * Handle the job failing by marking the deployment as failed.
      *
@@ -54,6 +59,6 @@ trait Trackable
             $message = 'This operation took too long.';
         }
 
-        $this->trackedJob->markAsFailed($message);
+        $this->trackedJob->markAsFailed($message . PHP_EOL . $this->appendToFailureOutput());
     }
 }

--- a/app/Jobs/WaitForImageToBeBuilt.php
+++ b/app/Jobs/WaitForImageToBeBuilt.php
@@ -43,4 +43,14 @@ class WaitForImageToBeBuilt implements ShouldQueue
             $operation->getUrl()
         );
     }
+
+    public function appendToFailureOutput()
+    {
+        $operation = $this->model->getBuildOperation();
+
+        return sprintf(
+            '<a href="%s" target="_blank">View the output in Cloud Build</a>.',
+            $operation->getUrl()
+        );
+    }
 }

--- a/app/Services/GitHub.php
+++ b/app/Services/GitHub.php
@@ -14,7 +14,8 @@ class GitHub implements SourceProviderClient
 {
     protected $source;
 
-    public function __construct(SourceProvider $source) {
+    public function __construct(SourceProvider $source)
+    {
         $this->source = $source;
     }
 
@@ -161,7 +162,8 @@ class GitHub implements SourceProviderClient
     /**
      * Get the access token for the given SourceProvider.
      */
-    protected function token() {
-        return $this->source->meta['token'];
+    protected function token()
+    {
+        return $this->source->token();
     }
 }

--- a/app/Services/GitHub.php
+++ b/app/Services/GitHub.php
@@ -109,7 +109,7 @@ class GitHub implements SourceProviderClient
             'https://api.github.com/repos/%s/tarball/%s?access_token=%s',
             $deployment->repository(),
             $deployment->commit_hash,
-            $this->token()
+            '$$TOKEN'
         );
     }
 

--- a/app/Services/GoogleApi.php
+++ b/app/Services/GoogleApi.php
@@ -372,7 +372,6 @@ class GoogleApi
      *
      * @param string $key
      * @param string $value
-     * @return \Google\Cloud\SecretManager\V1\SecretVersion;
      */
     public function setSecret(string $key, string $value)
     {
@@ -413,6 +412,17 @@ class GoogleApi
         }
     }
 
+    public function getProjectIamPolicys($email)
+    {
+        $account = urlencode($email);
+        return $this->request(
+            // "https://iam.googleapis.com/v1/projects/{$this->googleProject->project_id}/serviceAccounts/{$account}:getIamPolicy",
+            "https://cloudresourcemanager.googleapis.com/v1/projects/{$this->googleProject->project_id}/serviceAccounts/{$email}:getIamPolicy",
+            'POST',
+            false
+        );
+    }
+
     /**
      * Request data from the Google Cloud API.
      *
@@ -424,10 +434,17 @@ class GoogleApi
     protected function request($endpoint, $method = 'GET', $data = [])
     {
         try {
-            return Http::withToken($this->token())
-                ->{$method}($endpoint, $data)
-                ->throw()
-                ->json();
+            if ($data === false) {
+                return Http::withToken($this->token())
+                    ->send($method, $endpoint)
+                    ->throw()
+                    ->json();
+            } else {
+                return Http::withToken($this->token())
+                    ->$method($endpoint, $data)
+                    ->throw()
+                    ->json();
+            }
         } catch (RequestException $exception) {
             Log::error($exception->response->body());
 

--- a/app/Services/GoogleApi.php
+++ b/app/Services/GoogleApi.php
@@ -13,6 +13,7 @@ use App\GoogleCloud\DatabaseConfig;
 use App\GoogleCloud\DatabaseInstanceConfig;
 use App\GoogleCloud\DatabaseOperation;
 use App\GoogleCloud\EnableApisOperation;
+use App\GoogleCloud\IamPolicy;
 use App\GoogleCloud\QueueConfig;
 use App\GoogleCloud\SchedulerJobConfig;
 use App\GoogleProject;
@@ -410,14 +411,35 @@ class GoogleApi
         }
     }
 
-    public function getProjectIamPolicys($email)
+    /**
+     * Get the IAM Policy for a Google Project.
+     *
+     * @return IamPolicy
+     */
+    public function getProjectIamPolicy(): IamPolicy
     {
-        $account = urlencode($email);
+        return new IamPolicy(
+            $this->request(
+                "https://cloudresourcemanager.googleapis.com/v1/projects/{$this->googleProject->project_id}:getIamPolicy",
+                'POST',
+                false
+            )
+        );
+    }
+
+    /**
+     * Set the IAM Policy for a Google Project.
+     *
+     * @return IamPolicy
+     */
+    public function setProjectIamPolicy(IamPolicy $policy)
+    {
         return $this->request(
-            // "https://iam.googleapis.com/v1/projects/{$this->googleProject->project_id}/serviceAccounts/{$account}:getIamPolicy",
-            "https://cloudresourcemanager.googleapis.com/v1/projects/{$this->googleProject->project_id}/serviceAccounts/{$email}:getIamPolicy",
+            "https://cloudresourcemanager.googleapis.com/v1/projects/{$this->googleProject->project_id}:setIamPolicy",
             'POST',
-            false
+            [
+                'policy' => $policy->getPolicy(),
+            ]
         );
     }
 

--- a/app/SourceProvider.php
+++ b/app/SourceProvider.php
@@ -23,6 +23,16 @@ class SourceProvider extends Model
     }
 
     /**
+     * Get the token for this source provider.
+     *
+     * @return string
+     */
+    public function token(): string
+    {
+        return $this->meta['token'];
+    }
+
+    /**
      * Get a source control provider client for the provider.
      *
      * @return \App\Contracts\SourceProviderClient

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "fideloper/proxy": "^4.0",
         "google/apiclient": "^2.0",
         "google/cloud-logging": "^1.20",
+        "google/cloud-secret-manager": "^1.0",
         "guzzlehttp/guzzle": "^6.5",
         "laravel/framework": "^7.0",
         "laravel/tinker": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37f257c8e6bb2e9cda008152a94da150",
+    "content-hash": "ebd6ea6ef299cc2dabdd58ca65a89c08",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -439,16 +439,16 @@
         },
         {
             "name": "google/apiclient",
-            "version": "v2.4.0",
+            "version": "v2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client.git",
-                "reference": "cd3c37998020d91ae4eafca4f26a92da4dabba83"
+                "reference": "1fdfe942f9aaf3064e621834a5e3047fccb3a6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/cd3c37998020d91ae4eafca4f26a92da4dabba83",
-                "reference": "cd3c37998020d91ae4eafca4f26a92da4dabba83",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/1fdfe942f9aaf3064e621834a5e3047fccb3a6da",
+                "reference": "1fdfe942f9aaf3064e621834a5e3047fccb3a6da",
                 "shasum": ""
             },
             "require": {
@@ -465,7 +465,7 @@
                 "cache/filesystem-adapter": "^0.3.2",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
                 "phpcompatibility/php-compatibility": "^9.2",
-                "phpunit/phpunit": "~4.8.36",
+                "phpunit/phpunit": "^4.8|^5.0",
                 "squizlabs/php_codesniffer": "~2.3",
                 "symfony/css-selector": "~2.1",
                 "symfony/dom-crawler": "~2.1"
@@ -496,7 +496,7 @@
             "keywords": [
                 "google"
             ],
-            "time": "2019-09-11T17:38:10+00:00"
+            "time": "2020-03-26T15:30:32+00:00"
         },
         {
             "name": "google/apiclient-services",
@@ -700,6 +700,55 @@
                 "Apache-2.0"
             ],
             "description": "Stackdriver Logging Client for PHP",
+            "time": "2020-04-07T20:58:05+00:00"
+        },
+        {
+            "name": "google/cloud-secret-manager",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-cloud-php-secret-manager.git",
+                "reference": "24615f1a0c8e22bc7532e203ab11d4e3456a9838"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-secret-manager/zipball/24615f1a0c8e22bc7532e203ab11d4e3456a9838",
+                "reference": "24615f1a0c8e22bc7532e203ab11d4e3456a9838",
+                "shasum": ""
+            },
+            "require": {
+                "google/gax": "^1.2.0"
+            },
+            "require-dev": {
+                "google/cloud-core": "^1.35",
+                "phpdocumentor/reflection": "^3.0",
+                "phpunit/phpunit": "^4.8|^5.0"
+            },
+            "suggest": {
+                "ext-grpc": "Enables use of gRPC, a universal high-performance RPC framework created by Google.",
+                "ext-protobuf": "Provides a significant increase in throughput over the pure PHP protobuf implementation. See https://cloud.google.com/php/grpc for installation instructions."
+            },
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "cloud-secret-manager",
+                    "path": "SecretManager",
+                    "entry": null,
+                    "target": "googleapis/google-cloud-php-secret-manager.git"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\Cloud\\SecretManager\\": "src",
+                    "GPBMetadata\\Google\\Cloud\\Secrets\\": "metadata",
+                    "GPBMetadata\\Google\\Cloud\\Secretmanager\\": "metadata"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Secret Manager Client for PHP",
             "time": "2020-04-07T20:58:05+00:00"
         },
         {

--- a/database/factories/SourceProviderFactory.php
+++ b/database/factories/SourceProviderFactory.php
@@ -12,6 +12,6 @@ $factory->define(SourceProvider::class, function (Faker $faker) {
         'name' => 'GitHub ' . $faker->text(10),
         'type' => 'GitHub',
         'installation_id' => $faker->randomNumber(),
-        'meta' => ['some' => 'stuff'],
+        'meta' => ['token' => 'notatoken'],
     ];
 });

--- a/database/migrations/2020_01_23_041922_create_google_projects_table.php
+++ b/database/migrations/2020_01_23_041922_create_google_projects_table.php
@@ -18,6 +18,7 @@ class CreateGoogleProjectsTable extends Migration
             $table->unsignedBigInteger('team_id');
             $table->string('name');
             $table->string('project_id');
+            $table->string('project_number')->nullable();
             $table->string('status')->default('pending');
             $table->string('operation_name')->nullable();
             $table->json('service_account_json');

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -39,11 +39,13 @@ class DatabaseSeeder extends Seeder
          */
         $googleProjectName = env('SEED_GOOGLE_PROJECT_NAME');
         $googleProjectId = env('SEED_GOOGLE_PROJECT_ID');
+        $googleProjectNumber = env('SEED_GOOGLE_PROJECT_NUMBER');
 
-        if ($googleProjectName && $googleProjectId && File::exists(__DIR__ . '/../../service-account.json')) {
+        if ($googleProjectName && $googleProjectId && $googleProjectNumber && File::exists(__DIR__ . '/../../service-account.json')) {
             $googleProject = $team->googleProjects()->create([
                 'name' => $googleProjectName,
                 'project_id' => $googleProjectId,
+                'project_number' => $googleProjectNumber,
                 'service_account_json' => json_decode(File::get(__DIR__ . '/../../service-account.json')),
             ]);
 

--- a/tests/Feature/DeploymentTest.php
+++ b/tests/Feature/DeploymentTest.php
@@ -2,20 +2,30 @@
 
 namespace Tests\Feature;
 
+use Google\Cloud\SecretManager\V1\SecretManagerServiceClient;
 use Google_Client;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Tests\Support\FakeGoogleApiClient;
+use Tests\Support\FakeGoogleSecretManagerClient;
 use Tests\TestCase;
 
 class DeploymentTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->instance(Google_Client::class, new FakeGoogleApiClient);
+        $this->app->bind(SecretManagerServiceClient::class, function () {
+            return new FakeGoogleSecretManagerClient;
+        });
+    }
+
     public function test_initial_deployment_works_as_expected()
     {
-        $this->app->instance(Google_Client::class, new FakeGoogleApiClient);
-
         Http::fake([
             // CreateImageForDeployment
             'cloudbuild.googleapis.com/v1/projects/*/builds' => Http::response(['name' => 'bar'], 200),
@@ -72,6 +82,7 @@ class DeploymentTest extends TestCase
 
         $steps = [
             'StartDeployment',
+            'SetBuildSecrets',
             'CreateImageForDeployment',
             'ConfigureQueues',
             'WaitForImageToBeBuilt',
@@ -95,8 +106,6 @@ class DeploymentTest extends TestCase
 
     public function test_deployment_is_marked_as_failed_if_a_job_fails()
     {
-        $this->app->instance(Google_Client::class, new FakeGoogleApiClient);
-
         Http::fake([
             // CreateImageForDeployment
             'cloudbuild.googleapis.com/v1/projects/*/builds' => Http::response(['something' => 'unexpected'], 200),
@@ -113,8 +122,6 @@ class DeploymentTest extends TestCase
 
     public function test_standard_deployment_works_as_expected()
     {
-        $this->app->instance(Google_Client::class, new FakeGoogleApiClient);
-
         Http::fake([
             // CreateImageForDeployment
             'cloudbuild.googleapis.com/v1/projects/*/builds' => Http::response(['name' => 'bar'], 200),
@@ -159,6 +166,7 @@ class DeploymentTest extends TestCase
 
         $steps = [
             'StartDeployment',
+            'SetBuildSecrets',
             'CreateImageForDeployment',
             'ConfigureQueues',
             'WaitForImageToBeBuilt',
@@ -178,8 +186,6 @@ class DeploymentTest extends TestCase
 
     public function test_deployment_can_be_redeployed()
     {
-        $this->app->instance(Google_Client::class, new FakeGoogleApiClient);
-
         Http::fake([
             // CreateImageForDeployment
             'cloudbuild.googleapis.com/v1/projects/*/builds' => Http::response(['name' => 'bar'], 200),
@@ -243,7 +249,49 @@ class DeploymentTest extends TestCase
 
     public function test_redeploy_performs_initial_deploy_if_no_successful_deployment_exists()
     {
-        $this->app->instance(Google_Client::class, new FakeGoogleApiClient);
+        Http::fake([
+            // CreateImageForDeployment
+            'cloudbuild.googleapis.com/v1/projects/*/builds' => Http::response(['name' => 'bar'], 200),
+
+            // WaitForImageToBeBuilt
+            'cloudbuild.googleapis.com/v1/bar' => Http::response([
+                'done' => true,
+                'metadata' => [
+                    'build' => [
+                        'id' => 'foo',
+                    ],
+                ],
+            ], 200),
+
+            'cloudbuild.googleapis.com/v1/projects/*/builds/foo' => Http::response([
+                'results' => [
+                    'images' => [
+                        [
+                            'name' => 'some/build',
+                            'digest' => 'foo',
+                        ],
+                    ],
+                ],
+            ], 200),
+
+            // WaitForCloudRunServiceToDeploy
+            'us-central1-run.googleapis.com/apis/serving.knative.dev/v1/namespaces/*/services/*' => Http::response($this->loadStub('cloud-run-service'), 200),
+
+            // EnsureAppIsPublic
+            'https://us-central1-run.googleapis.com/v1/projects/*/locations/*/services/*:getIamPolicy' => Http::response([
+                'bindings' => [
+                    [
+                        'role' => 'roles/run.invoker',
+                        'members' => [
+                            'allUsers',
+                        ],
+                    ],
+                ],
+            ], 200),
+
+            // Stub a string response for all other endpoints...
+            '*' => Http::response('Hello World', 200, ['Headers']),
+        ]);
 
         $environment = factory('App\Environment')->state('laravel')->create();
 
@@ -256,6 +304,7 @@ class DeploymentTest extends TestCase
 
         $steps = [
             'StartDeployment',
+            'SetBuildSecrets',
             'CreateImageForDeployment',
             'ConfigureQueues',
             'WaitForImageToBeBuilt',

--- a/tests/Support/FakeGoogleSecretManagerClient.php
+++ b/tests/Support/FakeGoogleSecretManagerClient.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Support;
+
+class FakeGoogleSecretManagerClient
+{
+    public function __construct(array $options = [])
+    {
+        # code...
+    }
+
+    public function projectName()
+    {
+        return '';
+    }
+
+    public function secretName()
+    {
+        return '';
+    }
+
+    public function getSecret()
+    {
+        return true;
+    }
+
+    public function addSecretVersion()
+    {
+        # code...
+    }
+}

--- a/tests/Unit/CloudRunIamPolicyTest.php
+++ b/tests/Unit/CloudRunIamPolicyTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\GoogleCloud\CloudRunIamPolicy;
+use Tests\TestCase;
+
+class CloudRunIamPolicyTest extends TestCase
+{
+    public function test_it_knows_whether_a_service_is_public()
+    {
+        $payload = [
+            'version' => 1,
+            'etag' => "BwWk/fff4lc=",
+            'bindings' => []
+        ];
+
+        $policy = new CloudRunIamPolicy($payload);
+
+        $this->assertFalse($policy->isPublic());
+
+        $payload = [
+            'version' => 1,
+            'etag' => "BwWk/fff4lc=",
+            'bindings' => [
+                [
+                    'role' => 'roles/run.invoker',
+                    'members' => ['allUsers'],
+                ]
+            ]
+        ];
+
+        $policy = new CloudRunIamPolicy($payload);
+
+        $this->assertTrue($policy->isPublic());
+    }
+
+    public function test_it_sets_public()
+    {
+        $payload = [
+            'version' => 1,
+            'etag' => "BwWk/fff4lc=",
+            'bindings' => []
+        ];
+
+        $policy = new CloudRunIamPolicy($payload);
+
+        $this->assertFalse($policy->isPublic());
+
+        $policy->setPublic();
+
+        $this->assertTrue($policy->isPublic());
+        $this->assertEquals([
+            [
+                'role' => 'roles/run.invoker',
+                'members' => ['allUsers'],
+            ]
+        ], $policy->getPolicy()['bindings']);
+    }
+
+    public function test_it_does_not_add_duplicate_members()
+    {
+        $payload = [
+            'version' => 1,
+            'etag' => "BwWk/fff4lc=",
+            'bindings' => [
+                [
+                    'role' => 'roles/run.invoker',
+                    'members' => ['allUsers'],
+                ]
+            ]
+        ];
+
+        $policy = new CloudRunIamPolicy($payload);
+        $policy->setPublic();
+
+        $this->assertTrue($policy->isPublic());
+        $this->assertEquals([
+            [
+                'role' => 'roles/run.invoker',
+                'members' => ['allUsers'],
+            ]
+        ], $policy->getPolicy()['bindings']);
+    }
+}

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -7,6 +7,7 @@ use App\Jobs\CreateCloudRunService;
 use App\Jobs\CreateImageForDeployment;
 use App\Jobs\EnsureAppIsPublic;
 use App\Jobs\FinalizeDeployment;
+use App\Jobs\SetBuildSecrets;
 use App\Jobs\StartDeployment;
 use App\Jobs\StartScheduler;
 use App\Jobs\UpdateCloudRunServiceWithUrls;
@@ -32,6 +33,7 @@ class EnvironmentTest extends TestCase
         $environment->createInitialDeployment();
 
         Queue::assertPushedWithChain(StartDeployment::class, [
+            SetBuildSecrets::class,
             CreateImageForDeployment::class,
             ConfigureQueues::class,
             WaitForImageToBeBuilt::class,
@@ -54,6 +56,7 @@ class EnvironmentTest extends TestCase
         $environment->createInitialDeployment();
 
         Queue::assertPushedWithChain(StartDeployment::class, [
+            SetBuildSecrets::class,
             CreateImageForDeployment::class,
             ConfigureQueues::class,
             WaitForImageToBeBuilt::class,

--- a/tests/Unit/IamPolicyTest.php
+++ b/tests/Unit/IamPolicyTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Unit;
 
-use App\GoogleCloud\ProjectIamPolicy;
+use App\GoogleCloud\IamPolicy;
 use Tests\TestCase;
 
-class ProjectIamPolicyTest extends TestCase
+class IamPolicyTest extends TestCase
 {
     public function test_it_adds_a_new_member_to_a_new_role()
     {
@@ -15,7 +15,7 @@ class ProjectIamPolicyTest extends TestCase
             'bindings' => []
         ];
 
-        $policy = new ProjectIamPolicy($payload);
+        $policy = new IamPolicy($payload);
 
         $policy->addMemberToRole('new-service@account.com', 'roles/someNewRole');
 
@@ -46,7 +46,7 @@ class ProjectIamPolicyTest extends TestCase
             ]
         ];
 
-        $policy = new ProjectIamPolicy($payload);
+        $policy = new IamPolicy($payload);
 
         $policy->addMemberToRole('new-service@account.com', 'roles/existingRole');
 
@@ -79,7 +79,7 @@ class ProjectIamPolicyTest extends TestCase
             ]
         ];
 
-        $policy = new ProjectIamPolicy($payload);
+        $policy = new IamPolicy($payload);
 
         $policy->addMemberToRole('old-service@account.com', 'roles/existingRole');
 

--- a/tests/Unit/ProjectIamPolicyTest.php
+++ b/tests/Unit/ProjectIamPolicyTest.php
@@ -7,15 +7,6 @@ use Tests\TestCase;
 
 class ProjectIamPolicyTest extends TestCase
 {
-    protected $policy;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->policy = $this->loadStub('project-iam-policies');
-    }
-
     public function test_it_adds_a_new_member_to_a_new_role()
     {
         $payload = [

--- a/tests/Unit/ProjectIamPolicyTest.php
+++ b/tests/Unit/ProjectIamPolicyTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\GoogleCloud\ProjectIamPolicy;
+use Tests\TestCase;
+
+class ProjectIamPolicyTest extends TestCase
+{
+    protected $policy;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->policy = $this->loadStub('project-iam-policies');
+    }
+
+    public function test_it_adds_a_new_member_to_a_new_role()
+    {
+        $payload = [
+            'version' => 1,
+            'etag' => "BwWk/fff4lc=",
+            'bindings' => []
+        ];
+
+        $policy = new ProjectIamPolicy($payload);
+
+        $policy->addMemberToRole('new-service@account.com', 'roles/someNewRole');
+
+        $expected = [
+            [
+                'role' => 'roles/someNewRole',
+                'members' => [
+                    'new-service@account.com',
+                ],
+            ]
+        ];
+
+        $this->assertEquals($expected, $policy->getPolicy()['bindings']);
+    }
+
+    public function test_it_adds_a_new_member_to_an_existing_role()
+    {
+        $payload = [
+            'version' => 1,
+            'etag' => "BwWk/fff4lc=",
+            'bindings' => [
+                [
+                    'role' => 'roles/existingRole',
+                    'members' => [
+                        'old-service@account.com',
+                    ],
+                ]
+            ]
+        ];
+
+        $policy = new ProjectIamPolicy($payload);
+
+        $policy->addMemberToRole('new-service@account.com', 'roles/existingRole');
+
+        $expected = [
+            [
+                'role' => 'roles/existingRole',
+                'members' => [
+                    'old-service@account.com',
+                    'new-service@account.com',
+                ],
+            ]
+        ];
+
+        $this->assertEquals($expected, $policy->getPolicy()['bindings']);
+    }
+
+
+    public function test_it_does_not_add_duplicate_members()
+    {
+        $payload = [
+            'version' => 1,
+            'etag' => "BwWk/fff4lc=",
+            'bindings' => [
+                [
+                    'role' => 'roles/existingRole',
+                    'members' => [
+                        'old-service@account.com',
+                    ],
+                ]
+            ]
+        ];
+
+        $policy = new ProjectIamPolicy($payload);
+
+        $policy->addMemberToRole('old-service@account.com', 'roles/existingRole');
+
+        $expected = [
+            [
+                'role' => 'roles/existingRole',
+                'members' => [
+                    'old-service@account.com',
+                ],
+            ]
+        ];
+
+        $this->assertEquals($expected, $policy->getPolicy()['bindings']);
+    }
+}

--- a/tests/stubs/project-iam-policies.json
+++ b/tests/stubs/project-iam-policies.json
@@ -1,0 +1,69 @@
+{
+    "version": 1,
+    "etag": "BwWk/fff4lc=",
+    "bindings": [
+        {
+            "role": "roles/cloudbuild.builds.builder",
+            "members": [
+                "serviceAccount:123456789@cloudbuild.gserviceaccount.com"
+            ]
+        },
+        {
+            "role": "roles/cloudbuild.serviceAgent",
+            "members": [
+                "serviceAccount:service-123456789@gcp-sa-cloudbuild.iam.gserviceaccount.com"
+            ]
+        },
+        {
+            "role": "roles/cloudscheduler.serviceAgent",
+            "members": [
+                "serviceAccount:service-123456789@gcp-sa-cloudscheduler.iam.gserviceaccount.com"
+            ]
+        },
+        {
+            "role": "roles/cloudtasks.serviceAgent",
+            "members": [
+                "serviceAccount:service-123456789@gcp-sa-cloudtasks.iam.gserviceaccount.com"
+            ]
+        },
+        {
+            "role": "roles/compute.serviceAgent",
+            "members": [
+                "serviceAccount:service-123456789@compute-system.iam.gserviceaccount.com"
+            ]
+        },
+        {
+            "role": "roles/editor",
+            "members": [
+                "serviceAccount:123456789-compute@developer.gserviceaccount.com",
+                "serviceAccount:123456789@cloudservices.gserviceaccount.com",
+                "serviceAccount:rafter-demo-project@appspot.gserviceaccount.com",
+                "serviceAccount:service-123456789@containerregistry.iam.gserviceaccount.com"
+            ]
+        },
+        {
+            "role": "roles/firebaserules.system",
+            "members": [
+                "serviceAccount:service-123456789@firebase-rules.iam.gserviceaccount.com"
+            ]
+        },
+        {
+            "role": "roles/owner",
+            "members": [
+                "serviceAccount:rafter@rafter-demo-project.iam.gserviceaccount.com"
+            ]
+        },
+        {
+            "role": "roles/run.serviceAgent",
+            "members": [
+                "serviceAccount:service-123456789@serverless-robot-prod.iam.gserviceaccount.com"
+            ]
+        },
+        {
+            "role": "roles/secretmanager.secretAccessor",
+            "members": [
+                "serviceAccount:123456789@cloudbuild.gserviceaccount.com"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #18.

This implements the new [Secret Manager API](https://cloud.google.com/secret-manager/docs/managing-secrets) to support building projects in Cloud Build _without_ sending the GitHub access token in plaintext. This is a more secure mechanism, and it also opens the door to allowing users to submit and access build-time secrets (for private dependencies, etc).

- Integrates Secret Manager API and sets the GitHub access token as a secret during deployments
- Adds IAM Policy support for Cloud Build to access the secrets
- Refactors IAM Policy shared behavior between Cloud Run IAM and Project IAM
- Updates Cloud Build config to use the tarball link instead of using Git to clone projects