### PR TITLE
Remove all unused imports.

### DIFF
--- a/app/Events/UserRegistered.php
+++ b/app/Events/UserRegistered.php
@@ -3,11 +3,8 @@
 namespace App\Events;
 
 use App\User;
-use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,7 +2,6 @@
 
 namespace App\Exceptions;
 
-use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Throwable;
 

--- a/app/GoogleCloud/CloudRunService.php
+++ b/app/GoogleCloud/CloudRunService.php
@@ -3,7 +3,6 @@
 namespace App\GoogleCloud;
 
 use Exception;
-use Illuminate\Support\Facades\Log;
 
 class CloudRunService
 {

--- a/app/GoogleCloud/DomainMappingResponse.php
+++ b/app/GoogleCloud/DomainMappingResponse.php
@@ -2,8 +2,6 @@
 
 namespace App\GoogleCloud;
 
-use Illuminate\Support\Str;
-
 class DomainMappingResponse
 {
     protected $response;

--- a/app/GoogleCloud/EnableApisOperation.php
+++ b/app/GoogleCloud/EnableApisOperation.php
@@ -2,8 +2,6 @@
 
 namespace App\GoogleCloud;
 
-use Illuminate\Support\Facades\Log;
-
 class EnableApisOperation
 {
     protected $operation;

--- a/app/Http/Controllers/CommandController.php
+++ b/app/Http/Controllers/CommandController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Command;
 use App\Environment;
 use App\Project;
-use Illuminate\Http\Request;
 
 class CommandController extends Controller
 {

--- a/app/Http/Controllers/EnvironmentDomainsController.php
+++ b/app/Http/Controllers/EnvironmentDomainsController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Environment;
 use App\Project;
-use Illuminate\Http\Request;
 
 class EnvironmentDomainsController extends Controller
 {

--- a/app/Http/Controllers/EnvironmentLogController.php
+++ b/app/Http/Controllers/EnvironmentLogController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Environment;
 use App\Project;
-use Illuminate\Http\Request;
 
 class EnvironmentLogController extends Controller
 {

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -3,8 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Services\GitHubApp;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class HomeController extends Controller
 {

--- a/app/Http/Controllers/HookDeploymentController.php
+++ b/app/Http/Controllers/HookDeploymentController.php
@@ -6,7 +6,6 @@ use App\Environment;
 use App\Services\GitHubApp;
 use App\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
 
 class HookDeploymentController extends Controller
 {

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -5,11 +5,8 @@ namespace App\Http\Controllers;
 use App\GoogleProject;
 use App\Http\Requests\CreateProjectRequest;
 use App\Project;
-use App\Rules\ValidRepository;
-use App\SourceProvider;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Validation\Rule;
 
 class ProjectController extends Controller
 {

--- a/app/Http/Controllers/RedeployDeploymentController.php
+++ b/app/Http/Controllers/RedeployDeploymentController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Deployment;
 use App\Environment;
 use App\Project;
-use Illuminate\Http\Request;
 
 class RedeployDeploymentController extends Controller
 {

--- a/app/Jobs/CheckDomainMappingStatus.php
+++ b/app/Jobs/CheckDomainMappingStatus.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Throwable;
 
 class CheckDomainMappingStatus implements ShouldQueue
 {

--- a/app/Jobs/CreateImageForDeployment.php
+++ b/app/Jobs/CreateImageForDeployment.php
@@ -3,7 +3,6 @@
 namespace App\Jobs;
 
 use App\GoogleCloud\CloudBuildConfig;
-use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;

--- a/app/Jobs/EnableProjectApis.php
+++ b/app/Jobs/EnableProjectApis.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Log;
 use Throwable;
 
 class EnableProjectApis implements ShouldQueue

--- a/app/Listeners/CreatePersonalTeamForUser.php
+++ b/app/Listeners/CreatePersonalTeamForUser.php
@@ -3,8 +3,6 @@
 namespace App\Listeners;
 
 use App\Events\UserRegistered;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
 
 class CreatePersonalTeamForUser
 {

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,6 @@
 namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
-use Illuminate\Support\Facades\Gate;
 
 class AuthServiceProvider extends ServiceProvider
 {

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -5,7 +5,6 @@ namespace App\Providers;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
-use Illuminate\Support\Facades\Event;
 
 class EventServiceProvider extends ServiceProvider
 {

--- a/app/Services/GitHub.php
+++ b/app/Services/GitHub.php
@@ -3,7 +3,6 @@
 namespace App\Services;
 
 use App\SourceProvider;
-use GuzzleHttp\Client;
 use App\Contracts\SourceProviderClient;
 use App\Deployment;
 use Exception;

--- a/app/SourceProviderClientFactory.php
+++ b/app/SourceProviderClientFactory.php
@@ -4,7 +4,6 @@ namespace App;
 
 use App\Services\FakeSourceProviderClient;
 use App\Services\GitHub;
-use App\SourceProvider;
 use InvalidArgumentException;
 
 class SourceProviderClientFactory

--- a/app/User.php
+++ b/app/User.php
@@ -2,7 +2,6 @@
 
 namespace App;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Environment;
 use App\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\File;

--- a/tests/Feature/CommandControllerTest.php
+++ b/tests/Feature/CommandControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class CommandControllerTest extends TestCase

--- a/tests/Feature/DatabaseInstanceControllerTest.php
+++ b/tests/Feature/DatabaseInstanceControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class DatabaseInstanceControllerTest extends TestCase

--- a/tests/Feature/DeploymentControllerTest.php
+++ b/tests/Feature/DeploymentControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class DeploymentControllerTest extends TestCase

--- a/tests/Feature/EnvironmentControllerTest.php
+++ b/tests/Feature/EnvironmentControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class EnvironmentControllerTest extends TestCase

--- a/tests/Feature/GoogleProjectControllerTest.php
+++ b/tests/Feature/GoogleProjectControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class GoogleProjectControllerTest extends TestCase

--- a/tests/Feature/ProjectControllerTest.php
+++ b/tests/Feature/ProjectControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class ProjectControllerTest extends TestCase

--- a/tests/Feature/SourceProviderControllerTest.php
+++ b/tests/Feature/SourceProviderControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class SourceProviderControllerTest extends TestCase


### PR DESCRIPTION
There are lots of useless namespace imports within the codebase that can safely be removed.