### PR TITLE
Add Options column & cast

### DIFF
--- a/app/Casts/Options.php
+++ b/app/Casts/Options.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Casts;
+
+use App\Options as OptionsValueObject;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class Options implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        return new OptionsValueObject(json_decode($value, true));
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  array  $value
+     * @param  array  $attributes
+     * @return string
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        return json_encode($value);
+    }
+}

--- a/app/Casts/Options.php
+++ b/app/Casts/Options.php
@@ -18,7 +18,7 @@ class Options implements CastsAttributes
      */
     public function get($model, $key, $value, $attributes)
     {
-        return new OptionsValueObject(json_decode($value, true));
+        return new OptionsValueObject(json_decode($value ?: '{}', true));
     }
 
     /**

--- a/app/Database.php
+++ b/app/Database.php
@@ -13,11 +13,7 @@ class Database extends Model
     const STATUS_ACTIVE = 'active';
     const STATUS_FAILED = 'failed';
 
-    protected $fillable = [
-        'name',
-        'status',
-        'operation_name',
-    ];
+    protected $guarded = [];
 
     public function databaseInstance()
     {

--- a/app/DatabaseInstance.php
+++ b/app/DatabaseInstance.php
@@ -92,7 +92,7 @@ class DatabaseInstance extends Model
      */
     public function assignRootPassword()
     {
-        $this->update(['root_password' => Str::random()]);
+        $this->setOption('root_password', Str::random());
     }
 
     /**

--- a/app/DatabaseInstance.php
+++ b/app/DatabaseInstance.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Str;
 
 class DatabaseInstance extends Model
 {
+    use HasOptions;
+
     const TYPES = [
         'mysql',
         // 'postgres',

--- a/app/DatabaseInstance.php
+++ b/app/DatabaseInstance.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use App\Casts\Options;
 use App\GoogleCloud\DatabaseInstanceConfig;
 use App\Jobs\MonitorDatabaseInstanceCreation;
 use App\Services\GoogleApi;
@@ -50,22 +51,11 @@ class DatabaseInstance extends Model
     const STATUS_ACTIVE = 'active';
     const STATUS_FAILED = 'failed';
 
-    protected $fillable = [
-        'name',
-        'type',
-        'version',
-        'tier',
-        'size',
-        'status',
-        'region',
-        'root_password',
-        'operation_name',
-        'synced',
-        'google_project_id',
-    ];
+    protected $guarded = [];
 
     protected $casts = [
         'synced' => 'boolean',
+        'options' => Options::class,
     ];
 
     public function googleProject()

--- a/app/Deployment.php
+++ b/app/Deployment.php
@@ -14,14 +14,7 @@ class Deployment extends Model
     const STATUS_SUCCESSFUL = 'successful';
     const STATUS_FAILED = 'failed';
 
-    protected $fillable = [
-        'operation_name',
-        'status',
-        'image',
-        'commit_hash',
-        'commit_message',
-        'initiator_id',
-    ];
+    protected $guarded = [];
 
     public function environment()
     {

--- a/app/Environment.php
+++ b/app/Environment.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Str;
 
 class Environment extends Model
 {
+    use HasOptions;
+
     const INITIAL_ENVIRONMENTS = [
         'production',
     ];

--- a/app/Environment.php
+++ b/app/Environment.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use App\Casts\Options;
 use App\GoogleCloud\SchedulerJobConfig;
 use App\Services\GoogleApi;
 use Illuminate\Database\Eloquent\Model;
@@ -19,10 +20,10 @@ class Environment extends Model
         'environmental_variables',
     ];
 
-    protected $fillable = [
-        'name',
-        'url',
-        'environmental_variables',
+    protected $guarded = [];
+
+    protected $casts = [
+        'options' => Options::class,
     ];
 
     public function project()

--- a/app/GoogleCloud/DatabaseInstanceConfig.php
+++ b/app/GoogleCloud/DatabaseInstanceConfig.php
@@ -8,7 +8,8 @@ class DatabaseInstanceConfig
 {
     public $databaseInstance;
 
-    public function __construct(DatabaseInstance $databaseInstance) {
+    public function __construct(DatabaseInstance $databaseInstance)
+    {
         $this->databaseInstance = $databaseInstance;
     }
 
@@ -22,17 +23,17 @@ class DatabaseInstanceConfig
 
     public function version()
     {
-        return $this->databaseInstance->version;
+        return $this->databaseInstance->getOption('version');
     }
 
     public function tier()
     {
-        return $this->databaseInstance->tier;
+        return $this->databaseInstance->getOption('tier');
     }
 
     public function size()
     {
-        return $this->databaseInstance->size;
+        return $this->databaseInstance->getOption('size');
     }
 
     public function settings()
@@ -47,12 +48,12 @@ class DatabaseInstanceConfig
 
     public function region()
     {
-        return $this->databaseInstance->region;
+        return $this->databaseInstance->getOption('region');
     }
 
     public function rootPassword()
     {
-        return $this->databaseInstance->rootPassword;
+        return $this->databaseInstance->getOption('rootPassword');
     }
 
     public function name()

--- a/app/GoogleProject.php
+++ b/app/GoogleProject.php
@@ -46,14 +46,7 @@ class GoogleProject extends Model
     const STATUS_READY = 'ready';
     const STATUS_FAILED = 'failed';
 
-    protected $fillable = [
-        'name',
-        'project_id',
-        'project_number',
-        'service_account_json',
-        'status',
-        'operation_name',
-    ];
+    protected $guarded = [];
 
     protected $casts = [
         'service_account_json' => 'array',

--- a/app/HasOptions.php
+++ b/app/HasOptions.php
@@ -3,12 +3,20 @@
 namespace App;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 trait HasOptions
 {
+    /**
+     * Get an option from the `options` column, falling back to any value provided in a
+     * $defaultOptions property on the model.
+     *
+     * @param string $key
+     * @return mixed
+     */
     public function getOption(string $key)
     {
-        $default = Arr::get($this->defaultOptions, $key);
+        $default = Arr::get($this->defaultOptions ?? [], $key);
 
         $option = $this->options[$key] ?? $default;
 
@@ -19,10 +27,33 @@ trait HasOptions
         return $option;
     }
 
+    /**
+     * Set an option in the `options` column and save the model.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return void
+     */
     public function setOption(string $key, $value)
     {
         $this->options[$key] = $value;
 
         $this->save();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasGetMutator($key)
+    {
+        return method_exists($this, 'get' . Str::studly($key) . 'Attribute') || null !== $this->getOption($key);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function mutateAttribute($key, $value)
+    {
+        return $this->getOption($key) ?: $this->{'get' . Str::studly($key) . 'Attribute'}($value);
     }
 }

--- a/app/HasOptions.php
+++ b/app/HasOptions.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App;
+
+use Illuminate\Support\Arr;
+
+trait HasOptions
+{
+    public function getOption(string $key)
+    {
+        $default = Arr::get($this->defaultOptions, $key);
+
+        $option = $this->options[$key] ?? $default;
+
+        if (Arr::accessible($option)) {
+            return array_merge($default ?? [], $option);
+        }
+
+        return $option;
+    }
+
+    public function setOption(string $key, $value)
+    {
+        $this->options[$key] = $value;
+
+        $this->save();
+    }
+}

--- a/app/Http/Controllers/DatabaseInstanceController.php
+++ b/app/Http/Controllers/DatabaseInstanceController.php
@@ -11,7 +11,8 @@ use Illuminate\Validation\Rule;
 
 class DatabaseInstanceController extends Controller
 {
-    public function __construct() {
+    public function __construct()
+    {
         $this->authorizeResource('App\DatabaseInstance');
     }
 
@@ -69,10 +70,12 @@ class DatabaseInstanceController extends Controller
             'name' => $request->name,
             'google_project_id' => $request->google_project_id,
             'type' => $request->type,
-            'version' => $request->version,
-            'tier' => $request->tier,
-            'size' => $request->size,
-            'region' => $request->region,
+            'options' => [
+                'version' => $request->version,
+                'tier' => $request->tier,
+                'size' => $request->size,
+                'region' => $request->region,
+            ],
         ]);
 
         try {

--- a/app/Options.php
+++ b/app/Options.php
@@ -4,35 +4,36 @@ namespace App;
 
 use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
 use JsonSerializable;
 
 class Options implements ArrayAccess, Arrayable, JsonSerializable
 {
     protected $value;
 
-    public function __construct(array $value)
+    public function __construct(array $value = [])
     {
         $this->value = $value;
     }
 
     public function offsetExists($offset): bool
     {
-        return isset($this->value[$offset]);
+        return Arr::has($this->value, $offset);
     }
 
     public function offsetGet($offset)
     {
-        return $this->value[$offset];
+        return Arr::get($this->value, $offset);
     }
 
     public function offsetSet($offset, $value): void
     {
-        $this->value[$offset] = $value;
+        Arr::set($this->value, $offset, $value);
     }
 
     public function offsetUnset($offset): void
     {
-        unset($this->value[$offset]);
+        Arr::pull($this->value, $offset);
     }
 
     public function toArray(): array

--- a/app/Options.php
+++ b/app/Options.php
@@ -11,7 +11,7 @@ class Options implements ArrayAccess, Arrayable, JsonSerializable
 {
     protected $value;
 
-    public function __construct(array $value = [])
+    public function __construct(array $value)
     {
         $this->value = $value;
     }

--- a/app/Options.php
+++ b/app/Options.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+class Options implements ArrayAccess, Arrayable, JsonSerializable
+{
+    protected $value;
+
+    public function __construct(array $value)
+    {
+        $this->value = $value;
+    }
+
+    public function offsetExists($offset): bool
+    {
+        return isset($this->value[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->value[$offset];
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        $this->value[$offset] = $value;
+    }
+
+    public function offsetUnset($offset): void
+    {
+        unset($this->value[$offset]);
+    }
+
+    public function toArray(): array
+    {
+        return $this->value;
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/app/Project.php
+++ b/app/Project.php
@@ -14,13 +14,10 @@ class Project extends Model
         'nodejs' => "Node.js",
     ];
 
-    protected $fillable = [
-        'name',
-        'region',
-        'google_project_id',
-        'type',
-        'repository',
-        'source_provider_id',
+    protected $guarded = [];
+
+    protected $casts = [
+        'options' => Options::class,
     ];
 
     public function team()

--- a/app/Project.php
+++ b/app/Project.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Project extends Model
 {
+    use HasOptions;
+
     /**
      * Possible Project types
      */

--- a/app/Project.php
+++ b/app/Project.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use App\Casts\Options;
 use Illuminate\Database\Eloquent\Model;
 
 class Project extends Model

--- a/app/SourceProvider.php
+++ b/app/SourceProvider.php
@@ -10,12 +10,7 @@ class SourceProvider extends Model
         'meta' => 'array',
     ];
 
-    protected $fillable = [
-        'name',
-        'type',
-        'meta',
-        'installation_id',
-    ];
+    protected $guarded = [];
 
     public function user()
     {

--- a/app/User.php
+++ b/app/User.php
@@ -14,9 +14,7 @@ class User extends Authenticatable
      *
      * @var array
      */
-    protected $fillable = [
-        'name', 'email', 'password',
-    ];
+    protected $guarded = [];
 
     /**
      * The attributes that should be hidden for arrays.

--- a/database/factories/DatabaseInstanceFactory.php
+++ b/database/factories/DatabaseInstanceFactory.php
@@ -10,9 +10,12 @@ $factory->define(DatabaseInstance::class, function (Faker $faker) {
         'google_project_id' => factory('App\GoogleProject'),
         'name' => $faker->slug,
         'type' => 'mysql',
-        'version' => 'MYSQL_5_7',
-        'tier' => 'db-f1-micro',
-        'size' => '10',
-        'region' => 'us-central1',
+        'options' => [
+            'version' => 'MYSQL_5_7',
+            'tier' => 'db-f1-micro',
+            'size' => '10',
+            'region' => 'us-central1',
+            'rootPassword' => 'notapassword',
+        ],
     ];
 });

--- a/database/migrations/2020_01_23_151913_create_projects_table.php
+++ b/database/migrations/2020_01_23_151913_create_projects_table.php
@@ -22,7 +22,7 @@ class CreateProjectsTable extends Migration
             $table->unsignedBigInteger('source_provider_id')->index();
             $table->string('region');
             $table->string('repository')->nullable();
-            $table->text('options')->default('{}');
+            $table->text('options')->nullable();
             $table->timestamps();
 
             $table->foreign('team_id')

--- a/database/migrations/2020_01_23_151913_create_projects_table.php
+++ b/database/migrations/2020_01_23_151913_create_projects_table.php
@@ -22,6 +22,7 @@ class CreateProjectsTable extends Migration
             $table->unsignedBigInteger('source_provider_id')->index();
             $table->string('region');
             $table->string('repository')->nullable();
+            $table->text('options');
             $table->timestamps();
 
             $table->foreign('team_id')

--- a/database/migrations/2020_01_23_151913_create_projects_table.php
+++ b/database/migrations/2020_01_23_151913_create_projects_table.php
@@ -22,7 +22,7 @@ class CreateProjectsTable extends Migration
             $table->unsignedBigInteger('source_provider_id')->index();
             $table->string('region');
             $table->string('repository')->nullable();
-            $table->text('options');
+            $table->text('options')->default('{}');
             $table->timestamps();
 
             $table->foreign('team_id')

--- a/database/migrations/2020_01_23_163438_create_database_instances_table.php
+++ b/database/migrations/2020_01_23_163438_create_database_instances_table.php
@@ -26,7 +26,7 @@ class CreateDatabaseInstancesTable extends Migration
             $table->string('operation_name')->nullable();
             $table->string('status')->default('pending');
             $table->boolean('synced')->default(false);
-            $table->text('options')->default('{}');
+            $table->text('options')->nullable();
             $table->timestamps();
 
             $table->foreign('google_project_id')

--- a/database/migrations/2020_01_23_163438_create_database_instances_table.php
+++ b/database/migrations/2020_01_23_163438_create_database_instances_table.php
@@ -26,7 +26,7 @@ class CreateDatabaseInstancesTable extends Migration
             $table->string('operation_name')->nullable();
             $table->string('status')->default('pending');
             $table->boolean('synced')->default(false);
-            $table->text('options');
+            $table->text('options')->default('{}');
             $table->timestamps();
 
             $table->foreign('google_project_id')

--- a/database/migrations/2020_01_23_163438_create_database_instances_table.php
+++ b/database/migrations/2020_01_23_163438_create_database_instances_table.php
@@ -26,6 +26,7 @@ class CreateDatabaseInstancesTable extends Migration
             $table->string('operation_name')->nullable();
             $table->string('status')->default('pending');
             $table->boolean('synced')->default(false);
+            $table->text('options');
             $table->timestamps();
 
             $table->foreign('google_project_id')

--- a/database/migrations/2020_01_23_163438_create_database_instances_table.php
+++ b/database/migrations/2020_01_23_163438_create_database_instances_table.php
@@ -18,11 +18,6 @@ class CreateDatabaseInstancesTable extends Migration
             $table->unsignedBigInteger('google_project_id');
             $table->string('name');
             $table->string('type');
-            $table->string('version');
-            $table->string('tier');
-            $table->string('size');
-            $table->string('region');
-            $table->string('root_password')->nullable();
             $table->string('operation_name')->nullable();
             $table->string('status')->default('pending');
             $table->boolean('synced')->default(false);

--- a/database/migrations/2020_01_23_172455_create_environments_table.php
+++ b/database/migrations/2020_01_23_172455_create_environments_table.php
@@ -25,7 +25,7 @@ class CreateEnvironmentsTable extends Migration
             $table->string('web_service_name')->nullable();
             $table->string('worker_service_name')->nullable();
             $table->mediumText('environmental_variables')->nullable();
-            $table->text('options');
+            $table->text('options')->default('{}');
             $table->timestamps();
 
             $table->foreign('project_id')

--- a/database/migrations/2020_01_23_172455_create_environments_table.php
+++ b/database/migrations/2020_01_23_172455_create_environments_table.php
@@ -25,7 +25,7 @@ class CreateEnvironmentsTable extends Migration
             $table->string('web_service_name')->nullable();
             $table->string('worker_service_name')->nullable();
             $table->mediumText('environmental_variables')->nullable();
-            $table->text('options')->default('{}');
+            $table->text('options')->nullable();
             $table->timestamps();
 
             $table->foreign('project_id')

--- a/database/migrations/2020_01_23_172455_create_environments_table.php
+++ b/database/migrations/2020_01_23_172455_create_environments_table.php
@@ -25,6 +25,7 @@ class CreateEnvironmentsTable extends Migration
             $table->string('web_service_name')->nullable();
             $table->string('worker_service_name')->nullable();
             $table->mediumText('environmental_variables')->nullable();
+            $table->text('options');
             $table->timestamps();
 
             $table->foreign('project_id')

--- a/tests/Unit/DatabaseInstanceConfigTest.php
+++ b/tests/Unit/DatabaseInstanceConfigTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\GoogleCloud\DatabaseInstanceConfig;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatabaseInstanceConfigTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_expected_defaults_are_set()
+    {
+        $instance = factory('App\DatabaseInstance')->make();
+
+        $config = (new DatabaseInstanceConfig($instance))->config();
+
+        $this->assertEquals('MYSQL_5_7', $config['databaseVersion']);
+        $this->assertEquals([
+            'tier' => 'db-f1-micro',
+            'kind' => 'sql#settings',
+            'dataDiskSizeGb' => 10,
+            'backupConfiguration' => [
+                'enabled' => true,
+                'kind' => 'sql#backupConfiguration',
+                'binaryLogEnabled' => true,
+            ],
+        ], $config['settings']);
+        $this->assertEquals($instance->name, $config['name']);
+        $this->assertEquals('us-central1', $config['region']);
+        $this->assertEquals('notapassword', $config['rootPassword']);
+    }
+}

--- a/tests/Unit/DatabaseInstanceTest.php
+++ b/tests/Unit/DatabaseInstanceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatabaseInstanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_connection_string_is_generated()
+    {
+        $instance = factory('App\DatabaseInstance')->create([
+            'google_project_id' => factory('App\GoogleProject')->create([
+                'project_id' => 'some-project',
+            ])->id,
+            'name' => 'my-db',
+        ]);
+
+        $this->assertEquals('some-project:us-central1:my-db', $instance->connectionString());
+    }
+
+    public function test_some_options_are_accessible_as_properties()
+    {
+        $instance = factory('App\DatabaseInstance')->create();
+
+        $this->assertEquals('MYSQL_5_7', $instance->version);
+        $this->assertEquals('db-f1-micro', $instance->tier);
+        $this->assertEquals('10', $instance->size);
+        $this->assertEquals('us-central1', $instance->region);
+        $this->assertEquals('notapassword', $instance->rootPassword);
+    }
+}

--- a/tests/Unit/HasOptionsTest.php
+++ b/tests/Unit/HasOptionsTest.php
@@ -56,6 +56,16 @@ class HasOptionsTest extends TestCase
                 'location' => 'us-east',
             ],
         ], $model->options->toArray());
+
+        $model->options = [
+            'something' => 'fun',
+        ];
+
+        $this->assertEquals('fun', $model->getOption('something'));
+
+        $this->assertEquals([
+            'something' => 'fun',
+        ], $model->options->toArray());
     }
 
     public function test_options_arrays_are_merged()

--- a/tests/Unit/HasOptionsTest.php
+++ b/tests/Unit/HasOptionsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Casts\Options;
+use App\HasOptions;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+use Tests\TestCase;
+
+class HasOptionsTest extends TestCase
+{
+    public function test_default_options_are_applied()
+    {
+        $model = new TestModel([
+            'options' => [],
+        ]);
+
+        $this->assertEquals('100GB', $model->getOption('size'));
+        $this->assertEquals(true, $model->getOption('backups.enabled'));
+    }
+
+    public function test_options_are_merged()
+    {
+        $model = new TestModel([
+            'options' => [
+                'size' => '200GB',
+                'backups' => [
+                    'location' => 'us-central1',
+                ],
+            ],
+        ]);
+
+        $this->assertEquals('200GB', $model->getOption('size'));
+        $this->assertEquals(true, $model->getOption('backups.enabled'));
+        $this->assertEquals('us-central1', $model->getOption('backups.location'));
+    }
+
+    public function test_options_are_set()
+    {
+        $model = new TestModel([
+            'options' => [],
+        ]);
+
+        // Directly set on the options object, because otherwise $this->save() is
+        // called on the setOption helper method, and this is just a dummy model.
+        $model->options['size'] = '150GB';
+        $model->options['backups.location'] = 'us-east';
+
+        $this->assertEquals('150GB', $model->getOption('size'));
+        $this->assertEquals(true, $model->getOption('backups.enabled'));
+        $this->assertEquals('us-east', $model->getOption('backups.location'));
+
+        $this->assertEquals([
+            'size' => '150GB',
+            'backups' => [
+                'location' => 'us-east',
+            ],
+        ], $model->options->toArray());
+    }
+
+    public function test_options_arrays_are_merged()
+    {
+        $model = new TestModel([
+            'options' => [],
+        ]);
+
+        $model->options['access.public'] = true;
+        $model->options['size'] = '150GB';
+        $model->options['backups.location'] = 'us-east';
+
+        $this->assertEquals(true, $model->getOption('access.public'));
+
+        $this->assertEquals([
+            'location' => 'us-east',
+            'enabled' => true,
+            'frequency' => 'daily',
+        ], $model->getOption('backups'));
+
+        $this->assertEquals([
+            'public' => true,
+        ], $model->getOption('access'));
+    }
+}
+
+class TestModel extends EloquentModel
+{
+    use HasOptions;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'options' => Options::class,
+    ];
+
+    protected $defaultOptions = [
+        'size' => '100GB',
+        'backups' => [
+            'enabled' => true,
+            'frequency' => 'daily',
+        ],
+    ];
+}


### PR DESCRIPTION
Inspired by [Custom Casts](https://laravel.com/docs/7.x/eloquent-mutators#custom-casts) introduced in Laravel 7 and [Taylor Otwell's demo](https://vimeo.com/showcase/7060635/video/394206872), I've added a new `App\Casts\Options`.

It lets us do some cool things:

```php
$model->options;

// ['something' => 'old']

$model->options['something'] = 'new';
$model->options['else'] = 'also-new';

$model->save();

$model->options;

// ['something' => 'new', 'else' => 'also-new']
```

I also added an extra layer on top to support **dot-notation getters and setters** as well as **default value merging and auto-saving**:

```php
class Model
{
  use HasOptions;

  protected $defaultOptions = [
    'size' => '10GB',
    'backups' => [
      'enabled' => 'true',
    ],
  ];
}

$model = new Model();

$model->setOption('backups.location', 'us-central1');

$model->getOption('backups');

// ['enabled' => true, 'location' => 'us-central1']
```

This helps Rafter in a number of ways:

- Allows us to persist helpful settings for things like Cloud SQL instance options, which are quite numerous and could change with time... **without needing database migrations**. We can simply update the default values array and add/remove items from the single column.
- Allows us to keep things more organized.

So far, my justification for moving things to `options`:

- Will it ever need to be queried via SQL? If not, **it can move to options**.

TODO:

- [x] Add test and fix behavior for `setOption` on an unsaved model