### PR TITLE
Use ::class notation

### DIFF
--- a/app/Command.php
+++ b/app/Command.php
@@ -9,6 +9,8 @@ use Google\Auth\Middleware\AuthTokenMiddleware;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use Illuminate\Database\Eloquent\Model;
+use App\User;
+use App\Environment;
 
 class Command extends Model
 {
@@ -21,12 +23,12 @@ class Command extends Model
 
     public function environment()
     {
-        return $this->belongsTo('App\Environment');
+        return $this->belongsTo(Environment::class);
     }
 
     public function user()
     {
-        return $this->belongsTo('App\User');
+        return $this->belongsTo(User::class);
     }
 
     /**

--- a/app/Database.php
+++ b/app/Database.php
@@ -6,6 +6,7 @@ use App\GoogleCloud\DatabaseConfig;
 use App\Jobs\MonitorDatabaseCreation;
 use App\Services\GoogleApi;
 use Illuminate\Database\Eloquent\Model;
+use App\DatabaseInstance;
 
 class Database extends Model
 {
@@ -17,7 +18,7 @@ class Database extends Model
 
     public function databaseInstance()
     {
-        return $this->belongsTo('App\DatabaseInstance');
+        return $this->belongsTo(DatabaseInstance::class);
     }
 
     /**

--- a/app/DatabaseInstance.php
+++ b/app/DatabaseInstance.php
@@ -8,6 +8,8 @@ use App\Jobs\MonitorDatabaseInstanceCreation;
 use App\Services\GoogleApi;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use App\Database;
+use App\GoogleProject;
 
 class DatabaseInstance extends Model
 {
@@ -62,12 +64,12 @@ class DatabaseInstance extends Model
 
     public function googleProject()
     {
-        return $this->belongsTo('App\GoogleProject');
+        return $this->belongsTo(GoogleProject::class);
     }
 
     public function databases()
     {
-        return $this->hasMany('App\Database');
+        return $this->hasMany(Database::class);
     }
 
     /**

--- a/app/Deployment.php
+++ b/app/Deployment.php
@@ -6,6 +6,9 @@ use App\GoogleCloud\CloudBuildConfig;
 use App\GoogleCloud\CloudRunConfig;
 use App\Services\GoogleApi;
 use Illuminate\Database\Eloquent\Model;
+use App\User;
+use App\TrackedJob;
+use App\Environment;
 
 class Deployment extends Model
 {
@@ -18,12 +21,12 @@ class Deployment extends Model
 
     public function environment()
     {
-        return $this->belongsTo('App\Environment');
+        return $this->belongsTo(Environment::class);
     }
 
     public function steps()
     {
-        return $this->morphMany('App\TrackedJob', 'trackable');
+        return $this->morphMany(TrackedJob::class, 'trackable');
     }
 
     public function project()
@@ -38,7 +41,7 @@ class Deployment extends Model
 
     public function initiator()
     {
-        return $this->belongsTo('App\User', 'initiator_id')->withDefault([
+        return $this->belongsTo(User::class, 'initiator_id')->withDefault([
             'name' => 'Anonymous User',
         ]);
     }

--- a/app/DomainMapping.php
+++ b/app/DomainMapping.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Client\RequestException;
 use Throwable;
+use App\Environment;
 
 class DomainMapping extends Model
 {
@@ -54,7 +55,7 @@ class DomainMapping extends Model
 
     public function environment()
     {
-        return $this->belongsTo('App\Environment');
+        return $this->belongsTo(Environment::class);
     }
 
     public function getMapping(): DomainMappingResponse

--- a/app/Environment.php
+++ b/app/Environment.php
@@ -9,6 +9,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Str;
+use App\Deployment;
+use App\DomainMapping;
+use App\Command;
+use App\Database;
+use App\Project;
 
 class Environment extends Model
 {
@@ -30,22 +35,22 @@ class Environment extends Model
 
     public function project()
     {
-        return $this->belongsTo('App\Project');
+        return $this->belongsTo(Project::class);
     }
 
     public function deployments()
     {
-        return $this->hasMany('App\Deployment')->latest('id');
+        return $this->hasMany(Deployment::class)->latest('id');
     }
 
     public function database()
     {
-        return $this->belongsTo('App\Database');
+        return $this->belongsTo(Database::class);
     }
 
     public function commands()
     {
-        return $this->hasMany('App\Command')->latest();
+        return $this->hasMany(Command::class)->latest();
     }
 
     public function sourceProvider()
@@ -55,7 +60,7 @@ class Environment extends Model
 
     public function domainMappings()
     {
-        return $this->hasMany('App\DomainMapping')->latest();
+        return $this->hasMany(DomainMapping::class)->latest();
     }
 
     /**
@@ -65,7 +70,7 @@ class Environment extends Model
      */
     public function activeDeployment()
     {
-        return $this->belongsTo('App\Deployment', 'active_deployment_id');
+        return $this->belongsTo(Deployment::class, 'active_deployment_id');
     }
 
     public function primaryDomain(): string

--- a/app/GoogleProject.php
+++ b/app/GoogleProject.php
@@ -10,6 +10,8 @@ use App\Jobs\SyncDatabaseInstances;
 use App\Jobs\WaitForProjectApisToBeEnabled;
 use App\Services\GoogleApi;
 use Illuminate\Database\Eloquent\Model;
+use App\DatabaseInstance;
+use App\Team;
 
 class GoogleProject extends Model
 {
@@ -58,12 +60,12 @@ class GoogleProject extends Model
 
     public function team()
     {
-        return $this->belongsTo('App\Team');
+        return $this->belongsTo(Team::class);
     }
 
     public function databaseInstances()
     {
-        return $this->hasMany('App\DatabaseInstance');
+        return $this->hasMany(DatabaseInstance::class);
     }
 
     /**

--- a/app/Http/Controllers/CommandController.php
+++ b/app/Http/Controllers/CommandController.php
@@ -10,7 +10,7 @@ class CommandController extends Controller
 {
     public function __construct()
     {
-        $this->authorizeResource('App\Command');
+        $this->authorizeResource(Command::class);
     }
 
     /**

--- a/app/Http/Controllers/DatabaseInstanceController.php
+++ b/app/Http/Controllers/DatabaseInstanceController.php
@@ -13,7 +13,7 @@ class DatabaseInstanceController extends Controller
 {
     public function __construct()
     {
-        $this->authorizeResource('App\DatabaseInstance');
+        $this->authorizeResource(DatabaseInstance::class);
     }
 
     /**

--- a/app/Http/Controllers/DeploymentController.php
+++ b/app/Http/Controllers/DeploymentController.php
@@ -11,7 +11,7 @@ class DeploymentController extends Controller
 {
     public function __construct()
     {
-        $this->authorizeResource('App\Deployment');
+        $this->authorizeResource(Deployment::class);
     }
 
     /**

--- a/app/Http/Controllers/EnvironmentController.php
+++ b/app/Http/Controllers/EnvironmentController.php
@@ -9,7 +9,7 @@ use Illuminate\Http\Request;
 class EnvironmentController extends Controller
 {
     public function __construct() {
-        $this->authorizeResource('App\Environment');
+        $this->authorizeResource(Environment::class);
     }
 
     /**

--- a/app/Http/Controllers/GoogleProjectController.php
+++ b/app/Http/Controllers/GoogleProjectController.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Auth;
 class GoogleProjectController extends Controller
 {
     public function __construct() {
-        $this->authorizeResource('App\GoogleProject');
+        $this->authorizeResource(GoogleProject::class);
     }
 
     /**

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -12,7 +12,7 @@ class ProjectController extends Controller
 {
     public function __construct()
     {
-        $this->authorizeResource('App\Project');
+        $this->authorizeResource(Project::class);
     }
 
     /**

--- a/app/Http/Controllers/SourceProviderController.php
+++ b/app/Http/Controllers/SourceProviderController.php
@@ -10,7 +10,7 @@ use Illuminate\Validation\ValidationException;
 class SourceProviderController extends Controller
 {
     public function __construct() {
-        $this->authorizeResource('App\SourceProvider');
+        $this->authorizeResource(SourceProvider::class);
     }
 
     public function index()

--- a/app/Project.php
+++ b/app/Project.php
@@ -4,6 +4,10 @@ namespace App;
 
 use App\Casts\Options;
 use Illuminate\Database\Eloquent\Model;
+use App\SourceProvider;
+use App\Environment;
+use App\GoogleProject;
+use App\Team;
 
 class Project extends Model
 {
@@ -25,22 +29,22 @@ class Project extends Model
 
     public function team()
     {
-        return $this->belongsTo('App\Team');
+        return $this->belongsTo(Team::class);
     }
 
     public function googleProject()
     {
-        return $this->belongsTo('App\GoogleProject');
+        return $this->belongsTo(GoogleProject::class);
     }
 
     public function environments()
     {
-        return $this->hasMany('App\Environment');
+        return $this->hasMany(Environment::class);
     }
 
     public function sourceProvider()
     {
-        return $this->belongsTo('App\SourceProvider');
+        return $this->belongsTo(SourceProvider::class);
     }
 
     /**

--- a/app/SourceProvider.php
+++ b/app/SourceProvider.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use App\User;
 
 class SourceProvider extends Model
 {
@@ -14,7 +15,7 @@ class SourceProvider extends Model
 
     public function user()
     {
-        return $this->belongsTo('App\User');
+        return $this->belongsTo(User::class);
     }
 
     /**

--- a/app/Team.php
+++ b/app/Team.php
@@ -3,6 +3,10 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use App\GoogleProject;
+use App\DatabaseInstance;
+use App\Project;
+use App\User;
 
 class Team extends Model
 {
@@ -23,27 +27,27 @@ class Team extends Model
 
     public function owner()
     {
-        return $this->belongsTo('App\User', 'user_id');
+        return $this->belongsTo(User::class, 'user_id');
     }
 
     public function users()
     {
-        return $this->belongsToMany('App\User');
+        return $this->belongsToMany(User::class);
     }
 
     public function googleProjects()
     {
-        return $this->hasMany('App\GoogleProject');
+        return $this->hasMany(GoogleProject::class);
     }
 
     public function projects()
     {
-        return $this->hasMany('App\Project');
+        return $this->hasMany(Project::class);
     }
 
     public function databaseInstances()
     {
-        return $this->hasManyThrough('App\DatabaseInstance', 'App\GoogleProject');
+        return $this->hasManyThrough(DatabaseInstance::class, GoogleProject::class);
     }
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -4,6 +4,8 @@ namespace App;
 
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Team;
+use App\SourceProvider;
 
 class User extends Authenticatable
 {
@@ -45,22 +47,22 @@ class User extends Authenticatable
 
     public function ownedTeams()
     {
-        return $this->hasMany('App\Team');
+        return $this->hasMany(Team::class);
     }
 
     public function teams()
     {
-        return $this->belongsToMany('App\Team');
+        return $this->belongsToMany(Team::class);
     }
 
     public function sourceProviders()
     {
-        return $this->hasMany('App\SourceProvider');
+        return $this->hasMany(SourceProvider::class);
     }
 
     public function currentTeam()
     {
-        return $this->belongsTo('App\Team', 'current_team_id');
+        return $this->belongsTo(Team::class, 'current_team_id');
     }
 
     public function setCurrentTeam(Team $team)

--- a/database/factories/CommandFactory.php
+++ b/database/factories/CommandFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\User;
+use App\Environment;
+
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use App\Command;
@@ -8,8 +11,8 @@ use Faker\Generator as Faker;
 $factory->define(Command::class, function (Faker $faker) {
     return [
         'command' => $faker->text(12),
-        'user_id' => factory('App\User'),
-        'environment_id' => factory('App\Environment'),
+        'user_id' => factory(User::class),
+        'environment_id' => factory(Environment::class),
         'status' => 'pending',
     ];
 });

--- a/database/factories/DatabaseFactory.php
+++ b/database/factories/DatabaseFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\DatabaseInstance;
+
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use App\Database;
@@ -8,6 +10,6 @@ use Faker\Generator as Faker;
 $factory->define(Database::class, function (Faker $faker) {
     return [
         'name' => $faker->slug(),
-        'database_instance_id' => factory('App\DatabaseInstance'),
+        'database_instance_id' => factory(DatabaseInstance::class),
     ];
 });

--- a/database/factories/DatabaseInstanceFactory.php
+++ b/database/factories/DatabaseInstanceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\GoogleProject;
+
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use App\DatabaseInstance;
@@ -7,7 +9,7 @@ use Faker\Generator as Faker;
 
 $factory->define(DatabaseInstance::class, function (Faker $faker) {
     return [
-        'google_project_id' => factory('App\GoogleProject'),
+        'google_project_id' => factory(GoogleProject::class),
         'name' => $faker->slug,
         'type' => 'mysql',
         'options' => [

--- a/database/factories/DeploymentFactory.php
+++ b/database/factories/DeploymentFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Environment;
+use App\User;
+
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use App\Deployment;
@@ -7,8 +10,8 @@ use Faker\Generator as Faker;
 
 $factory->define(Deployment::class, function (Faker $faker) {
     return [
-        'environment_id' => factory('App\Environment'),
-        'initiator_id' => factory('App\User'),
+        'environment_id' => factory(Environment::class),
+        'initiator_id' => factory(User::class),
         'commit_message' => $faker->text(40),
     ];
 });

--- a/database/factories/DomainMappingFactory.php
+++ b/database/factories/DomainMappingFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Environment;
+
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use App\DomainMapping;
@@ -9,6 +11,6 @@ $factory->define(DomainMapping::class, function (Faker $faker) {
     return [
         'domain' => $faker->domainName,
         'status' => 'inactive',
-        'environment_id' => factory('App\Environment'),
+        'environment_id' => factory(Environment::class),
     ];
 });

--- a/database/factories/EnvironmentFactory.php
+++ b/database/factories/EnvironmentFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Project;
+
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use App\Environment;
@@ -7,19 +9,19 @@ use Faker\Generator as Faker;
 
 $factory->define(Environment::class, function (Faker $faker) {
     return [
-        'project_id' => factory('App\Project'),
+        'project_id' => factory(Project::class),
         'name' => $faker->slug(),
     ];
 });
 
 $factory->state(Environment::class, 'laravel', function ($faker) {
     return [
-        'project_id' => factory('App\Project')->state('laravel'),
+        'project_id' => factory(Project::class)->state('laravel'),
     ];
 });
 
 $factory->state(Environment::class, 'nodejs', function ($faker) {
     return [
-        'project_id' => factory('App\Project')->state('nodejs'),
+        'project_id' => factory(Project::class)->state('nodejs'),
     ];
 });

--- a/database/factories/GoogleProjectFactory.php
+++ b/database/factories/GoogleProjectFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Team;
+
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use App\GoogleProject;
@@ -7,7 +9,7 @@ use Faker\Generator as Faker;
 
 $factory->define(GoogleProject::class, function (Faker $faker) {
     return [
-        'team_id' => factory('App\Team'),
+        'team_id' => factory(Team::class),
         'project_id' => $faker->slug(),
         'name' => $faker->text(20),
         'service_account_json' => [

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -1,5 +1,9 @@
 <?php
 
+use App\Team;
+use App\GoogleProject;
+use App\SourceProvider;
+
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use App\Project;
@@ -9,9 +13,9 @@ $factory->define(Project::class, function (Faker $faker) {
     return [
         'name' => $faker->text(20),
         'type' => $faker->randomElement(array_keys(Project::TYPES)),
-        'team_id' => factory('App\Team'),
-        'google_project_id' => factory('App\GoogleProject'),
-        'source_provider_id' => factory('App\SourceProvider'),
+        'team_id' => factory(Team::class),
+        'google_project_id' => factory(GoogleProject::class),
+        'source_provider_id' => factory(SourceProvider::class),
         'repository' => 'rafter/rafter',
         'region' => 'us-central1',
     ];

--- a/database/factories/SourceProviderFactory.php
+++ b/database/factories/SourceProviderFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\User;
+
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use App\Model;
@@ -8,7 +10,7 @@ use Faker\Generator as Faker;
 
 $factory->define(SourceProvider::class, function (Faker $faker) {
     return [
-        'user_id' => factory('App\User'),
+        'user_id' => factory(User::class),
         'name' => 'GitHub ' . $faker->text(10),
         'type' => 'GitHub',
         'installation_id' => $faker->randomNumber(),

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\User;
+
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use App\Team;
@@ -7,7 +9,7 @@ use Faker\Generator as Faker;
 
 $factory->define(Team::class, function (Faker $faker) {
     return [
-        'user_id' => factory('App\User'),
+        'user_id' => factory(User::class),
         'name' => $faker->name(),
     ];
 });

--- a/tests/Feature/CommandControllerTest.php
+++ b/tests/Feature/CommandControllerTest.php
@@ -4,6 +4,10 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\Command;
+use App\User;
+use App\Environment;
+use App\Project;
 
 class CommandControllerTest extends TestCase
 {
@@ -16,30 +20,30 @@ class CommandControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->user = factory('App\User')->create();
-        $this->other = factory('App\Command')->create();
+        $this->user = factory(User::class)->create();
+        $this->other = factory(Command::class)->create();
     }
 
     public function test_user_can_view_their_commands()
     {
-        $project = factory('App\Project')->create([
+        $project = factory(Project::class)->create([
             'team_id' => $this->user->currentTeam->id,
         ]);
 
-        $environment = factory('App\Environment')->create([
+        $environment = factory(Environment::class)->create([
             'project_id' => $project->id,
         ]);
 
-        $commands = factory('App\Command', 3)->create([
+        $commands = factory(Command::class, 3)->create([
             'environment_id' => $environment->id,
             'user_id' => $this->user->id,
         ]);
 
         // Also ensure command created by another user on the same team is visible
-        $otherTeamMember = factory('App\User')->create();
+        $otherTeamMember = factory(User::class)->create();
         $this->user->currentTeam->users()->attach($otherTeamMember);
 
-        $otherCommandOnTeam = factory('App\Command')->create([
+        $otherCommandOnTeam = factory(Command::class)->create([
             'environment_id' => $environment->id,
             'user_id' => $otherTeamMember->id,
         ]);

--- a/tests/Feature/DatabaseInstanceControllerTest.php
+++ b/tests/Feature/DatabaseInstanceControllerTest.php
@@ -4,6 +4,9 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\GoogleProject;
+use App\DatabaseInstance;
+use App\User;
 
 class DatabaseInstanceControllerTest extends TestCase
 {
@@ -16,14 +19,14 @@ class DatabaseInstanceControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->user = factory('App\User')->create();
-        $this->other = factory('App\DatabaseInstance')->create();
+        $this->user = factory(User::class)->create();
+        $this->other = factory(DatabaseInstance::class)->create();
     }
 
     public function test_user_can_view_their_database_instances()
     {
-        $dbs = factory('App\DatabaseInstance', 3)->create([
-            'google_project_id' => factory('App\GoogleProject')->create([
+        $dbs = factory(DatabaseInstance::class, 3)->create([
+            'google_project_id' => factory(GoogleProject::class)->create([
                 'team_id' => $this->user->currentTeam->id,
             ]),
         ]);

--- a/tests/Feature/DeploymentControllerTest.php
+++ b/tests/Feature/DeploymentControllerTest.php
@@ -4,6 +4,10 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\Deployment;
+use App\Environment;
+use App\Project;
+use App\User;
 
 class DeploymentControllerTest extends TestCase
 {
@@ -16,21 +20,21 @@ class DeploymentControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->user = factory('App\User')->create();
-        $this->other = factory('App\Deployment')->create();
+        $this->user = factory(User::class)->create();
+        $this->other = factory(Deployment::class)->create();
     }
 
     public function test_user_can_view_their_deployments()
     {
-        $project = factory('App\Project')->create([
+        $project = factory(Project::class)->create([
             'team_id' => $this->user->currentTeam->id,
         ]);
 
-        $environment = factory('App\Environment')->create([
+        $environment = factory(Environment::class)->create([
             'project_id' => $project->id,
         ]);
 
-        $deployments = factory('App\Deployment', 3)->create([
+        $deployments = factory(Deployment::class, 3)->create([
             'environment_id' => $environment->id,
         ]);
 

--- a/tests/Feature/DeploymentTest.php
+++ b/tests/Feature/DeploymentTest.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Facades\Http;
 use Tests\Support\FakeGoogleApiClient;
 use Tests\Support\FakeGoogleSecretManagerClient;
 use Tests\TestCase;
+use App\Deployment;
+use App\Environment;
 
 class DeploymentTest extends TestCase
 {
@@ -70,7 +72,7 @@ class DeploymentTest extends TestCase
             '*' => Http::response('Hello World', 200, ['Headers']),
         ]);
 
-        $environment = factory('App\Environment')->state('laravel')->create();
+        $environment = factory(Environment::class)->state('laravel')->create();
 
         $deployment = $environment->createInitialDeployment();
 
@@ -111,7 +113,7 @@ class DeploymentTest extends TestCase
             'cloudbuild.googleapis.com/v1/projects/*/builds' => Http::response(['something' => 'unexpected'], 200),
         ]);
 
-        $environment = factory('App\Environment')->state('laravel')->create();
+        $environment = factory(Environment::class)->state('laravel')->create();
 
         $deployment = $environment->createInitialDeployment();
 
@@ -154,7 +156,7 @@ class DeploymentTest extends TestCase
             '*' => Http::response('Hello World', 200, ['Headers']),
         ]);
 
-        $environment = factory('App\Environment')->state('laravel')->create();
+        $environment = factory(Environment::class)->state('laravel')->create();
 
         $deployment = $environment->deployHash('abc123', 'commit message', null);
 
@@ -218,7 +220,7 @@ class DeploymentTest extends TestCase
             '*' => Http::response('Hello World', 200, ['Headers']),
         ]);
 
-        $environment = factory('App\Environment')->state('laravel')->create();
+        $environment = factory(Environment::class)->state('laravel')->create();
 
         $deployment = $environment->deployHash('abc123', 'commit message', null);
 
@@ -293,9 +295,9 @@ class DeploymentTest extends TestCase
             '*' => Http::response('Hello World', 200, ['Headers']),
         ]);
 
-        $environment = factory('App\Environment')->state('laravel')->create();
+        $environment = factory(Environment::class)->state('laravel')->create();
 
-        $failedDeployment = factory('App\Deployment')->create([
+        $failedDeployment = factory(Deployment::class)->create([
             'environment_id' => $environment->id,
             'status' => 'failed',
         ]);

--- a/tests/Feature/DomainMappingTest.php
+++ b/tests/Feature/DomainMappingTest.php
@@ -15,6 +15,9 @@ use Tests\Support\FakeGoogleApiClient;
 use Tests\TestCase;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
+use App\Project;
+use App\Environment;
+use App\User;
 
 class DomainMappingTest extends TestCase
 {
@@ -162,7 +165,7 @@ class DomainMappingTest extends TestCase
         $mapping = $this->createMapping();
         $mapping->markActive();
 
-        $this->actingAs(factory('App\User')->create());
+        $this->actingAs(factory(User::class)->create());
 
         Livewire::test(EnvironmentDomains::class, ['environment' => $mapping->environment])
             ->call('deleteDomain', $mapping->id);
@@ -209,7 +212,7 @@ class DomainMappingTest extends TestCase
         $mapping = $this->createMapping();
         $mapping->markActive();
 
-        $this->actingAs(factory('App\User')->create());
+        $this->actingAs(factory(User::class)->create());
 
         Livewire::test(EnvironmentDomains::class, ['environment' => $mapping->environment])
             ->call('checkDomainStatus', $mapping->id);
@@ -253,7 +256,7 @@ class DomainMappingTest extends TestCase
         $mapping = $this->createMapping();
         $mapping->markUnverified();
 
-        $this->actingAs(factory('App\User')->create());
+        $this->actingAs(factory(User::class)->create());
 
         Livewire::test(EnvironmentDomains::class, ['environment' => $mapping->environment])
             ->call('verifyDomain', $mapping->id);
@@ -263,11 +266,11 @@ class DomainMappingTest extends TestCase
 
     protected function createMapping(): DomainMapping
     {
-        return factory('App\DomainMapping')->create([
+        return factory(DomainMapping::class)->create([
             'domain' => 'www.rafter.app',
-            'environment_id' => factory('App\Environment')->create([
+            'environment_id' => factory(Environment::class)->create([
                 'name' => 'production',
-                'project_id' => factory('App\Project')->create([
+                'project_id' => factory(Project::class)->create([
                     'name' => 'rafter'
                 ])->id,
             ])->id,

--- a/tests/Feature/EnvironmentControllerTest.php
+++ b/tests/Feature/EnvironmentControllerTest.php
@@ -4,6 +4,9 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\Environment;
+use App\Project;
+use App\User;
 
 class EnvironmentControllerTest extends TestCase
 {
@@ -16,17 +19,17 @@ class EnvironmentControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->user = factory('App\User')->create();
-        $this->other = factory('App\Environment')->create();
+        $this->user = factory(User::class)->create();
+        $this->other = factory(Environment::class)->create();
     }
 
     public function test_user_can_view_their_environments()
     {
-        $project = factory('App\Project')->create([
+        $project = factory(Project::class)->create([
             'team_id' => $this->user->currentTeam->id,
         ]);
 
-        $environment = factory('App\Environment')->create([
+        $environment = factory(Environment::class)->create([
             'project_id' => $project->id,
         ]);
 

--- a/tests/Feature/EnvironmentDomainsControllerTest.php
+++ b/tests/Feature/EnvironmentDomainsControllerTest.php
@@ -5,6 +5,10 @@ namespace Tests\Feature;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
+use App\User;
+use App\DomainMapping;
+use App\Environment;
+use App\Project;
 
 class EnvironmentDomainsController extends TestCase
 {
@@ -17,26 +21,26 @@ class EnvironmentDomainsController extends TestCase
     {
         parent::setUp();
 
-        $this->user = factory('App\User')->create();
-        $this->other = factory('App\User')->create();
+        $this->user = factory(User::class)->create();
+        $this->other = factory(User::class)->create();
     }
 
     public function test_user_can_view_their_domains()
     {
-        $project = factory('App\Project')->create([
+        $project = factory(Project::class)->create([
             'team_id' => $this->user->currentTeam->id,
         ]);
 
-        $environment = factory('App\Environment')->create([
+        $environment = factory(Environment::class)->create([
             'project_id' => $project->id,
         ]);
 
-        $domains = factory('App\DomainMapping', 3)->create([
+        $domains = factory(DomainMapping::class, 3)->create([
             'environment_id' => $environment->id,
         ]);
 
         // Also ensure domain created by another user on the same team is visible
-        $otherTeamMember = factory('App\User')->create();
+        $otherTeamMember = factory(User::class)->create();
         $this->user->currentTeam->users()->attach($otherTeamMember);
         $otherTeamMember->setCurrentTeam($this->user->currentTeam);
         $this->user->currentTeam->refresh();

--- a/tests/Feature/GoogleProjectControllerTest.php
+++ b/tests/Feature/GoogleProjectControllerTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\GoogleProject;
+use App\User;
 
 class GoogleProjectControllerTest extends TestCase
 {
@@ -16,13 +18,13 @@ class GoogleProjectControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->user = factory('App\User')->create();
-        $this->otherProject = factory('App\GoogleProject')->create();
+        $this->user = factory(User::class)->create();
+        $this->otherProject = factory(GoogleProject::class)->create();
     }
 
     public function test_user_can_view_their_projects()
     {
-        $projects = factory('App\GoogleProject', 3)->create([
+        $projects = factory(GoogleProject::class, 3)->create([
             'team_id' => $this->user->currentTeam->id,
         ]);
 

--- a/tests/Feature/ProjectControllerTest.php
+++ b/tests/Feature/ProjectControllerTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\Project;
+use App\User;
 
 class ProjectControllerTest extends TestCase
 {
@@ -16,13 +18,13 @@ class ProjectControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->user = factory('App\User')->create();
-        $this->otherProject = factory('App\Project')->create();
+        $this->user = factory(User::class)->create();
+        $this->otherProject = factory(Project::class)->create();
     }
 
     public function test_user_can_view_their_projects()
     {
-        $projects = factory('App\Project', 3)->create([
+        $projects = factory(Project::class, 3)->create([
             'team_id' => $this->user->currentTeam->id,
         ]);
 

--- a/tests/Feature/SourceProviderControllerTest.php
+++ b/tests/Feature/SourceProviderControllerTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\SourceProvider;
+use App\User;
 
 class SourceProviderControllerTest extends TestCase
 {
@@ -16,13 +18,13 @@ class SourceProviderControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->user = factory('App\User')->create();
-        $this->other = factory('App\SourceProvider')->create();
+        $this->user = factory(User::class)->create();
+        $this->other = factory(SourceProvider::class)->create();
     }
 
     public function test_user_can_view_their_source_providers()
     {
-        $sources = factory('App\SourceProvider', 3)->create([
+        $sources = factory(SourceProvider::class, 3)->create([
             'user_id' => $this->user->id,
         ]);
 

--- a/tests/Unit/DatabaseInstanceConfigTest.php
+++ b/tests/Unit/DatabaseInstanceConfigTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use App\GoogleCloud\DatabaseInstanceConfig;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\DatabaseInstance;
 
 class DatabaseInstanceConfigTest extends TestCase
 {
@@ -12,7 +13,7 @@ class DatabaseInstanceConfigTest extends TestCase
 
     public function test_expected_defaults_are_set()
     {
-        $instance = factory('App\DatabaseInstance')->make();
+        $instance = factory(DatabaseInstance::class)->make();
 
         $config = (new DatabaseInstanceConfig($instance))->config();
 

--- a/tests/Unit/DatabaseInstanceTest.php
+++ b/tests/Unit/DatabaseInstanceTest.php
@@ -4,6 +4,8 @@ namespace Tests\Unit;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\DatabaseInstance;
+use App\GoogleProject;
 
 class DatabaseInstanceTest extends TestCase
 {
@@ -11,8 +13,8 @@ class DatabaseInstanceTest extends TestCase
 
     public function test_connection_string_is_generated()
     {
-        $instance = factory('App\DatabaseInstance')->create([
-            'google_project_id' => factory('App\GoogleProject')->create([
+        $instance = factory(DatabaseInstance::class)->create([
+            'google_project_id' => factory(GoogleProject::class)->create([
                 'project_id' => 'some-project',
             ])->id,
             'name' => 'my-db',
@@ -23,7 +25,7 @@ class DatabaseInstanceTest extends TestCase
 
     public function test_some_options_are_accessible_as_properties()
     {
-        $instance = factory('App\DatabaseInstance')->create();
+        $instance = factory(DatabaseInstance::class)->create();
 
         $this->assertEquals('MYSQL_5_7', $instance->version);
         $this->assertEquals('db-f1-micro', $instance->tier);

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -19,6 +19,8 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Tests\Support\FakeGoogleApiClient;
 use Tests\TestCase;
+use App\DomainMapping;
+use App\Environment;
 
 class EnvironmentTest extends TestCase
 {
@@ -28,7 +30,7 @@ class EnvironmentTest extends TestCase
     {
         Queue::fake();
 
-        $environment = factory('App\Environment')->state('laravel')->create();
+        $environment = factory(Environment::class)->state('laravel')->create();
 
         $environment->createInitialDeployment();
 
@@ -49,7 +51,7 @@ class EnvironmentTest extends TestCase
 
     public function test_create_initial_deployment_enqueues_expected_jobs_for_nodejs()
     {
-        $environment = factory('App\Environment')->state('nodejs')->create();
+        $environment = factory(Environment::class)->state('nodejs')->create();
 
         Queue::fake();
 
@@ -75,7 +77,7 @@ class EnvironmentTest extends TestCase
 
         $this->app->instance(Google_Client::class, new FakeGoogleApiClient);
 
-        $environment = factory('App\Environment')->state('laravel')->create([
+        $environment = factory(Environment::class)->state('laravel')->create([
             'worker_url' => 'https://some.a.run.app',
         ]);
 
@@ -94,14 +96,14 @@ class EnvironmentTest extends TestCase
 
     public function test_primary_domain_is_known()
     {
-        $environment = factory('App\Environment')->state('laravel')->create([
+        $environment = factory(Environment::class)->state('laravel')->create([
             'url' => 'https://some.a.run.app',
         ]);
 
         $this->assertEquals('some.a.run.app', $environment->primaryDomain());
 
         // Throw in an inactive mapping to ensure it doesn't count as a primary domain
-        $environment->domainMappings()->create(factory('App\DomainMapping')->raw([
+        $environment->domainMappings()->create(factory(DomainMapping::class)->raw([
             'status' => 'inactive',
         ]));
 
@@ -109,7 +111,7 @@ class EnvironmentTest extends TestCase
 
         $this->assertEquals('some.a.run.app', $environment->primaryDomain());
 
-        $mapping = $environment->domainMappings()->create(factory('App\DomainMapping')->raw([
+        $mapping = $environment->domainMappings()->create(factory(DomainMapping::class)->raw([
             'status' => 'active',
         ]));
 
@@ -120,13 +122,13 @@ class EnvironmentTest extends TestCase
 
     public function test_knows_additional_domains()
     {
-        $environment = factory('App\Environment')->state('laravel')->create([
+        $environment = factory(Environment::class)->state('laravel')->create([
             'url' => 'https://some.a.run.app',
         ]);
 
         $this->assertEquals(0, $environment->additionalDomainsCount());
 
-        $environment->domainMappings()->createMany(factory('App\DomainMapping', 5)->raw([
+        $environment->domainMappings()->createMany(factory(DomainMapping::class, 5)->raw([
             'status' => 'active',
         ]));
 


### PR DESCRIPTION
Always use `::class` notation.
It makes renaming, moving and refactoring much easier.