### PR TITLE
Do not export .styleci.yml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 * text=auto
-*.css linguist-vendored
-*.scss linguist-vendored
-*.js linguist-vendored
-CHANGELOG.md export-ignore
+
+.styleci.yml   export-ignore
+CHANGELOG.md   export-ignore


### PR DESCRIPTION
Do not export `.styleci.yml`
@jplhomer, can you make sure to enable StyleCI: https://styleci.io
This is free for the public Github repositories and really handy.