### PR TITLE
Update instead of Create when Cloud Run service already exists

### DIFF
--- a/app/Deployment.php
+++ b/app/Deployment.php
@@ -210,6 +210,27 @@ class Deployment extends Model
     }
 
     /**
+     * When attempting to create a new Cloud Run service, and one already exists,
+     * we want to ensure that we set the web and worker service names properly so
+     * the service can be updated as expected. Further, we import the env vars from
+     * the existing service to ensure we don't lose them in the next deploy.
+     *
+     * @return void
+     */
+    public function importExistingCloudRunService()
+    {
+        $config = new CloudRunConfig($this);
+
+        $this->environment->setWebName($config->name());
+        $this->environment->setWorkerName($config->forWorker()->name());
+
+        $service = $this->getCloudRunWebService();
+        $envVars = new EnvVars($service->envVars());
+
+        $this->environment->environmental_variables = $envVars->toString();
+    }
+
+    /**
      * Redeploy a given deployment
      *
      * @param int|null $initiatorId

--- a/app/Deployment.php
+++ b/app/Deployment.php
@@ -227,7 +227,7 @@ class Deployment extends Model
         $service = $this->getCloudRunWebService();
         $envVars = new EnvVars($service->envVars());
 
-        $this->environment->environmental_variables = $envVars->toString();
+        $this->environment->update(['environmental_variables' => $envVars->toString()]);
     }
 
     /**

--- a/app/GoogleCloud/CloudRunService.php
+++ b/app/GoogleCloud/CloudRunService.php
@@ -8,7 +8,8 @@ class CloudRunService
 {
     protected $service;
 
-    public function __construct($service) {
+    public function __construct($service)
+    {
         $this->service = $service;
     }
 
@@ -29,7 +30,7 @@ class CloudRunService
      */
     public function hasStatus()
     {
-        return ! empty($this->status());
+        return !empty($this->status());
     }
 
     /**
@@ -112,14 +113,15 @@ class CloudRunService
         return $this->status()['url'] ?? null;
     }
 
-    /**
-     * Get the metadata
-     *
-     * @return array
-     */
-    public function metadata()
+    public function envVars(): array
     {
-        return $this->services['metadata'];
+        $vars = [];
+
+        foreach ($this->service['spec']['template']['spec']['containers'][0]['env'] ?? [] as $var) {
+            $vars[$var['name']] = $var['value'];
+        }
+
+        return $vars;
     }
 
     /**
@@ -144,4 +146,6 @@ class CloudRunService
 }
 
 
-class InvalidConditionException extends Exception {}
+class InvalidConditionException extends Exception
+{
+}

--- a/app/Jobs/CreateCloudRunService.php
+++ b/app/Jobs/CreateCloudRunService.php
@@ -23,12 +23,8 @@ class CreateCloudRunService implements ShouldQueue
             $body = $e->response->json();
 
             if ($body['error']['status'] == 'ALREADY_EXISTS') {
-                $config = new CloudRunConfig($this->model);
-
-                $this->model->environment->setWebName($config->name());
-                $this->model->environment->setWorkerName($config->forWorker()->name());
-
-                $this->model->updateCloudRunService();
+                $this->model->importExistingCloudRunService();
+                $this->model->refresh()->updateCloudRunService();
                 $this->model->updateCloudRunWorkerService();
 
                 return "Existing Cloud Run services detected. Updating those services with the latest image instead.";

--- a/app/Jobs/CreateCloudRunService.php
+++ b/app/Jobs/CreateCloudRunService.php
@@ -2,9 +2,11 @@
 
 namespace App\Jobs;
 
+use App\GoogleCloud\CloudRunConfig;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 
@@ -14,8 +16,26 @@ class CreateCloudRunService implements ShouldQueue
 
     public function handle()
     {
-        $this->model->createCloudRunService();
-        $this->model->createCloudRunWorkerService();
+        try {
+            $this->model->createCloudRunService();
+            $this->model->createCloudRunWorkerService();
+        } catch (RequestException $e) {
+            $body = $e->response->json();
+
+            if ($body['error']['status'] == 'ALREADY_EXISTS') {
+                $config = new CloudRunConfig($this->model);
+
+                $this->model->environment->setWebName($config->name());
+                $this->model->environment->setWorkerName($config->forWorker()->name());
+
+                $this->model->updateCloudRunService();
+                $this->model->updateCloudRunWorkerService();
+
+                return "Existing Cloud Run services detected. Updating those services with the latest image instead.";
+            }
+
+            throw $e;
+        }
 
         return true;
     }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -42,6 +42,7 @@ class DatabaseSeeder extends Seeder
 
         if ($googleProjectId && $googleProjectNumber && File::exists(__DIR__ . '/../../service-account.json')) {
             $googleProject = $team->googleProjects()->create([
+                'status' => 'ready',
                 'project_id' => $googleProjectId,
                 'project_number' => $googleProjectNumber,
                 'service_account_json' => json_decode(File::get(__DIR__ . '/../../service-account.json')),

--- a/tests/Feature/DeploymentTest.php
+++ b/tests/Feature/DeploymentTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\EnvVars;
+use App\Jobs\CreateCloudRunService;
 use Google\Cloud\SecretManager\V1\SecretManagerServiceClient;
 use Google_Client;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -321,5 +323,44 @@ class DeploymentTest extends TestCase
 
         $this->assertCount(count($steps), $deployment->steps);
         $this->assertSame($steps, $deployment->steps()->pluck('name')->toArray());
+    }
+
+    public function test_cloud_run_service_is_updated_instead_of_created_on_initial_deployment_if_already_exists()
+    {
+        Http::fake([
+            // The first attempt to create a new service will fail
+            'us-central1-run.googleapis.com/apis/serving.knative.dev/v1/namespaces/*/services' => Http::response(['error' => ['status' => 'ALREADY_EXISTS']], 409),
+
+            /**
+             * The next attempts to
+             * 1) get the current service and
+             * 2) update the service
+             * will simply get the service in response.
+             */
+            'us-central1-run.googleapis.com/apis/serving.knative.dev/v1/namespaces/*/services/*' => Http::response($this->loadStub('cloud-run-service')),
+        ]);
+
+        $environment = factory('App\Environment')->state('laravel')->create();
+
+        $this->assertEquals('', $environment->environmental_variables);
+        $this->assertEquals('', $environment->web_service_name);
+        $this->assertEquals('', $environment->worker_service_name);
+
+        $deployment = $environment->deployments()->create([
+            'commit_hash' => 'abc123',
+            'commit_message' => 'Initial Deploy',
+        ]);
+
+        CreateCloudRunService::dispatchNow($deployment);
+
+        // Ensure the vars from the existing service are re-used
+        $this->assertEquals([
+            'DB_CONNECTION' => 'sqlite',
+            'DB_DATABASE' => '/var/www/database/database.sqlite',
+        ], EnvVars::fromString($environment->refresh()->environmental_variables)->get());
+
+        // Ensure the web and worker values are now set
+        $this->assertEquals($environment->slug(), $environment->web_service_name);
+        $this->assertEquals($environment->slug() . '-worker', $environment->worker_service_name);
     }
 }

--- a/tests/Unit/CloudRunServiceTest.php
+++ b/tests/Unit/CloudRunServiceTest.php
@@ -50,4 +50,14 @@ class CloudRunServiceTest extends TestCase
             $service->getError()
         );
     }
+
+    public function test_it_shows_env_vars()
+    {
+        $service = new CloudRunService($this->loadStub('cloud-run-service'));
+
+        $this->assertEquals([
+            'DB_CONNECTION' => 'sqlite',
+            'DB_DATABASE' => '/var/www/database/database.sqlite',
+        ], $service->envVars());
+    }
 }


### PR DESCRIPTION
This solves a little issue if you're trying to deploy a new Cloud Run service, but one already exists with the given name(s).

This checks to see if the service already exists, and updates it instead.

- [x] One thing to consider: should we try to pull down the ENV vars and update those locally before updating the service?
- [x] Add tests