### PR TITLE
Implement GitHub Deployment API

### DIFF
--- a/app/Contracts/SourceProviderClient.php
+++ b/app/Contracts/SourceProviderClient.php
@@ -76,4 +76,14 @@ interface SourceProviderClient
      * Fetch a token.
      */
     public function token(): string;
+
+    /**
+     * Create a new deployment within the provider's API.
+     */
+    public function createDeployment(Deployment $deployment);
+
+    /**
+     * Update a deployment's status.
+     */
+    public function updateDeploymentStatus(Deployment $deployment, string $state);
 }

--- a/app/Deployment.php
+++ b/app/Deployment.php
@@ -102,6 +102,7 @@ class Deployment extends Model
     public function markAsFailed()
     {
         $this->update(['status' => static::STATUS_FAILED]);
+        $this->sourceProvider()->updateDeploymentStatus($this, 'failure');
     }
 
     /**

--- a/app/Deployment.php
+++ b/app/Deployment.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use App\Casts\Options;
 use App\GoogleCloud\CloudBuildConfig;
 use App\GoogleCloud\CloudRunConfig;
 use App\Services\GoogleApi;
@@ -13,6 +14,10 @@ class Deployment extends Model
     const STATUS_IN_PROGRESS = 'in_progress';
     const STATUS_SUCCESSFUL = 'successful';
     const STATUS_FAILED = 'failed';
+
+    protected $casts = [
+        'meta' => Options::class,
+    ];
 
     protected $guarded = [];
 
@@ -280,6 +285,16 @@ class Deployment extends Model
         }
 
         return $vars;
+    }
+
+    public function createSourceProviderDeployment()
+    {
+        $this->sourceProvider()->createDeployment($this);
+    }
+
+    public function updateSourceProviderDeploymentStatus(string $state)
+    {
+        $this->sourceProvider()->updateDeploymentStatus($this, $state);
     }
 
     public function getRoute(): string

--- a/app/Jobs/FinalizeDeployment.php
+++ b/app/Jobs/FinalizeDeployment.php
@@ -15,6 +15,7 @@ class FinalizeDeployment implements ShouldQueue
     public function handle()
     {
         $this->model->markAsSuccessful();
+        $this->model->updateSourceProviderDeploymentStatus('success');
 
         $environment = $this->model->environment;
 

--- a/app/Jobs/StartDeployment.php
+++ b/app/Jobs/StartDeployment.php
@@ -15,6 +15,7 @@ class StartDeployment implements ShouldQueue
     public function handle()
     {
         $this->model->markAsInProgress();
+        $this->model->createSourceProviderDeployment();
 
         return true;
     }

--- a/app/Services/FakeSourceProviderClient.php
+++ b/app/Services/FakeSourceProviderClient.php
@@ -94,4 +94,14 @@ class FakeSourceProviderClient implements SourceProviderClient
     {
         return 'notatoken';
     }
+
+    public function createDeployment(Deployment $deployment)
+    {
+        //
+    }
+
+    public function updateDeploymentStatus(Deployment $deployment, string $state)
+    {
+        //
+    }
 }

--- a/app/Services/GitHub.php
+++ b/app/Services/GitHub.php
@@ -79,7 +79,7 @@ class GitHub implements SourceProviderClient
 
         try {
             $response = $this->request("repos/{$repository}/commits/{$hash}");
-        } catch (ClientException $e) {
+        } catch (RequestException $e) {
             return false;
         }
 
@@ -213,6 +213,34 @@ class GitHub implements SourceProviderClient
             ->json();
     }
 
+    public function createDeployment(Deployment $deployment)
+    {
+        $response = $this->request("repos/{$deployment->repository()}/deployments", 'POST', [
+            'ref' => $deployment->commit_hash,
+            'environment' => $deployment->environment->name,
+            'description' => 'Deploy request from Rafter',
+        ]);
+
+        $deploymentId = $response['id'];
+        $deployment->meta['github_deployment_id'] = $deploymentId;
+        $deployment->save();
+
+        $this->updateDeploymentStatus($deployment, 'in_progress');
+    }
+
+    public function updateDeploymentStatus(Deployment $deployment, $state)
+    {
+        $this->request("repos/{$deployment->repository()}/deployments/{$deployment->meta['github_deployment_id']}/statuses", 'POST', [
+            'state' => $state,
+            'log_url' => route('projects.environments.deployments.show', [
+                $deployment->project(),
+                $deployment->environment,
+                $deployment
+            ]),
+            'environment_url' => $deployment->environment->url,
+        ]);
+    }
+
     /**
      * Create a JWT to call the GitHub API.
      *
@@ -233,13 +261,17 @@ class GitHub implements SourceProviderClient
 
     protected function request($endpoint, $method = 'get', $data = [])
     {
-        return Http::withHeaders([
-            'Authorization' => "token {$this->token()}",
-            'Accept' => "application/vnd.github.machine-man-preview+json",
-        ])
-            ->{$method}('https://api.github.com/' . $endpoint, $data)
-            ->throw()
-            ->json();
+        try {
+            return Http::withToken($this->token(), 'token')
+                ->accept("application/vnd.github.machine-man-preview+json, application/vnd.github.ant-man-preview+json, application/vnd.github.flash-preview+json")
+                ->{$method}('https://api.github.com/' . $endpoint, $data)
+                ->throw()
+                ->json();
+        } catch (RequestException $exception) {
+            logger()->error($exception->response->body());
+
+            throw $exception;
+        }
     }
 
     /**

--- a/app/SourceProvider.php
+++ b/app/SourceProvider.php
@@ -82,4 +82,14 @@ class SourceProvider extends Model
     {
         return $this->type == static::TYPE_GITHUB;
     }
+
+    public function createDeployment(Deployment $deployment)
+    {
+        $this->client()->createDeployment($deployment);
+    }
+
+    public function updateDeploymentStatus(Deployment $deployment, string $state)
+    {
+        $this->client()->updateDeploymentStatus($deployment, $state);
+    }
 }

--- a/database/migrations/2020_01_23_205108_create_deployments_table.php
+++ b/database/migrations/2020_01_23_205108_create_deployments_table.php
@@ -22,6 +22,7 @@ class CreateDeploymentsTable extends Migration
             $table->string('image')->nullable();
             $table->string('commit_hash')->nullable();
             $table->string('commit_message')->nullable();
+            $table->text('meta')->nullable();
             $table->timestamps();
 
             $table->foreign('environment_id')

--- a/resources/views/livewire/deployment-status.blade.php
+++ b/resources/views/livewire/deployment-status.blade.php
@@ -1,8 +1,8 @@
 <div wire:poll>
     <div class="bg-white">
         <div class="p-4 border-b">
-            <div class="flex items-center justify-between mb-1">
-                <div class="flex items-center">
+            <div class="flex flex-wrap items-center justify-between mb-1">
+                <div class="flex flex-wrap items-center">
                     <h1 class="text-xl mr-4">{{ $deployment->commit_message }}</h1>
                     <x-status :status="$deployment->status" />
                 </div>

--- a/resources/views/livewire/deployments-list.blade.php
+++ b/resources/views/livewire/deployments-list.blade.php
@@ -26,7 +26,7 @@
         @foreach ($deployments as $idx => $deployment)
             <x-tr :idx="$idx">
                 <x-td>
-                    <a href="{{ $deployment->getRoute() }}">{{ $deployment->commit_message }}</a>
+                    <a class="max-w-md overflow-hidden whitespace-no-wrap block" style="text-overflow: ellipsis" href="{{ $deployment->getRoute() }}">{{ $deployment->commit_message }}</a>
                 </x-td>
                 <x-td>
                     <x-status :status="$deployment->status" />

--- a/tests/Feature/DeploymentTest.php
+++ b/tests/Feature/DeploymentTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use App\EnvVars;
 use App\Jobs\CreateCloudRunService;
+use App\Jobs\StartDeployment;
+use App\Services\FakeSourceProviderClient;
 use Google\Cloud\SecretManager\V1\SecretManagerServiceClient;
 use Google_Client;
 use Illuminate\Foundation\Testing\RefreshDatabase;


### PR DESCRIPTION
Fixes #19.

Adds integration into the [GitHub Deployment API](https://developer.github.com/v3/repos/deployments/#create-a-deployment).

Pairs really nicely with the Slack app integration.

<img width="390" alt="Screen Shot 2020-06-17 at 9 12 35 PM" src="https://user-images.githubusercontent.com/848147/84969911-46c91400-b0df-11ea-8cdb-f4335a351270.png">

TODO: This feels like something that could eventually be dispatched using Events instead. For now, explicit is OK.

- [x] Figure out the deal with `commit_statuses`. If tests fail, am I unable to create a deployment? Or can I skip them specifically?